### PR TITLE
MultiCI: Refactor Remote cache accesses behind a class

### DIFF
--- a/sources/src/caching/cache-utils.ts
+++ b/sources/src/caching/cache-utils.ts
@@ -30,47 +30,52 @@ export function hashStrings(values: string[]): string {
     return hash.digest('hex')
 }
 
-export async function restoreCache(
-    cachePath: string[],
-    cacheKey: string,
-    cacheRestoreKeys: string[],
-    listener: CacheEntryListener
-): Promise<cache.CacheEntry | undefined> {
-    listener.markRequested(cacheKey, cacheRestoreKeys)
-    try {
-        const startTime = Date.now()
-        // Only override the read timeout if the SEGMENT_DOWNLOAD_TIMEOUT_MINS env var has NOT been set
-        const cacheRestoreOptions = process.env[SEGMENT_DOWNLOAD_TIMEOUT_VAR]
-            ? {}
-            : {segmentTimeoutInMs: SEGMENT_DOWNLOAD_TIMEOUT_DEFAULT}
-        const restoredEntry = await cache.restoreCache(cachePath, cacheKey, cacheRestoreKeys, cacheRestoreOptions)
-        if (restoredEntry !== undefined) {
-            const restoreTime = Date.now() - startTime
-            listener.markRestored(restoredEntry.key, restoredEntry.size, restoreTime)
-            core.info(`Restored cache entry with key ${cacheKey} to ${cachePath.join()} in ${restoreTime}ms`)
+/**
+ * Provides access to a remote cache (e.g. Github Actions cache)
+ */
+export class RemoteCacheAccessor {
+    async restoreCache(
+        cachePath: string[],
+        cacheKey: string,
+        cacheRestoreKeys: string[],
+        listener: CacheEntryListener
+    ): Promise<cache.CacheEntry | undefined> {
+        listener.markRequested(cacheKey, cacheRestoreKeys)
+        try {
+            const startTime = Date.now()
+            // Only override the read timeout if the SEGMENT_DOWNLOAD_TIMEOUT_MINS env var has NOT been set
+            const cacheRestoreOptions = process.env[SEGMENT_DOWNLOAD_TIMEOUT_VAR]
+                ? {}
+                : {segmentTimeoutInMs: SEGMENT_DOWNLOAD_TIMEOUT_DEFAULT}
+            const restoredEntry = await cache.restoreCache(cachePath, cacheKey, cacheRestoreKeys, cacheRestoreOptions)
+            if (restoredEntry !== undefined) {
+                const restoreTime = Date.now() - startTime
+                listener.markRestored(restoredEntry.key, restoredEntry.size, restoreTime)
+                core.info(`Restored cache entry with key ${cacheKey} to ${cachePath.join()} in ${restoreTime}ms`)
+            }
+            return restoredEntry
+        } catch (error) {
+            listener.markNotRestored((error as Error).message)
+            handleCacheFailure(error, `Failed to restore ${cacheKey}`)
+            return undefined
         }
-        return restoredEntry
-    } catch (error) {
-        listener.markNotRestored((error as Error).message)
-        handleCacheFailure(error, `Failed to restore ${cacheKey}`)
-        return undefined
     }
-}
 
-export async function saveCache(cachePath: string[], cacheKey: string, listener: CacheEntryListener): Promise<void> {
-    try {
-        const startTime = Date.now()
-        const savedEntry = await cache.saveCache(cachePath, cacheKey)
-        const saveTime = Date.now() - startTime
-        listener.markSaved(savedEntry.key, savedEntry.size, saveTime)
-        core.info(`Saved cache entry with key ${cacheKey} from ${cachePath.join()} in ${saveTime}ms`)
-    } catch (error) {
-        if (error instanceof cache.ReserveCacheError) {
-            listener.markAlreadyExists(cacheKey)
-        } else {
-            listener.markNotSaved((error as Error).message)
+    async saveCache(cachePath: string[], cacheKey: string, listener: CacheEntryListener): Promise<void> {
+        try {
+            const startTime = Date.now()
+            const savedEntry = await cache.saveCache(cachePath, cacheKey)
+            const saveTime = Date.now() - startTime
+            listener.markSaved(savedEntry.key, savedEntry.size, saveTime)
+            core.info(`Saved cache entry with key ${cacheKey} from ${cachePath.join()} in ${saveTime}ms`)
+        } catch (error) {
+            if (error instanceof cache.ReserveCacheError) {
+                listener.markAlreadyExists(cacheKey)
+            } else {
+                listener.markNotSaved((error as Error).message)
+            }
+            handleCacheFailure(error, `Failed to save cache entry with path '${cachePath}' and key: ${cacheKey}`)
         }
-        handleCacheFailure(error, `Failed to save cache entry with path '${cachePath}' and key: ${cacheKey}`)
     }
 }
 

--- a/sources/src/caching/caches.ts
+++ b/sources/src/caching/caches.ts
@@ -11,6 +11,7 @@ import {DaemonController} from '../daemon-controller'
 import {CacheConfig} from '../configuration'
 import {BuildResults} from '../build-results'
 import {CacheKeyGenerator} from './cache-key'
+import {RemoteCacheAccessor} from './cache-utils'
 
 const CACHE_RESTORED_VAR = 'GRADLE_BUILD_ACTION_CACHE_RESTORED'
 
@@ -28,7 +29,13 @@ export async function restore(
     core.exportVariable(CACHE_RESTORED_VAR, true)
 
     // TODO(Nava2): Move `new CacheKeyGenerator()` to a class property.
-    const gradleStateCache = new GradleUserHomeCache(userHome, gradleUserHome, cacheConfig, new CacheKeyGenerator())
+    const gradleStateCache = new GradleUserHomeCache(
+        userHome,
+        gradleUserHome,
+        cacheConfig,
+        new RemoteCacheAccessor(),
+        new CacheKeyGenerator()
+    )
 
     if (cacheConfig.isCacheDisabled()) {
         core.info('Cache is disabled: will not restore state from previous builds.')
@@ -113,7 +120,10 @@ export async function save(
 
     await core.group('Caching Gradle state', async () => {
         const cacheKeyGenerator = new CacheKeyGenerator()
-        return new GradleUserHomeCache(userHome, gradleUserHome, cacheConfig, cacheKeyGenerator).save(cacheListener)
+        const cacheAccessor = new RemoteCacheAccessor()
+        return new GradleUserHomeCache(userHome, gradleUserHome, cacheConfig, cacheAccessor, cacheKeyGenerator).save(
+            cacheListener
+        )
     })
 }
 

--- a/sources/src/caching/gradle-home-extry-extractor.ts
+++ b/sources/src/caching/gradle-home-extry-extractor.ts
@@ -4,7 +4,7 @@ import * as core from '@actions/core'
 import * as glob from '@actions/glob'
 
 import {CacheEntryListener, CacheListener} from './cache-reporting'
-import {cacheDebug, hashFileNames, isCacheDebuggingEnabled, restoreCache, saveCache, tryDelete} from './cache-utils'
+import {cacheDebug, hashFileNames, isCacheDebuggingEnabled, RemoteCacheAccessor, tryDelete} from './cache-utils'
 
 import {BuildResult, loadBuildResults} from '../build-results'
 import {CacheConfig, ACTION_METADATA_DIR} from '../configuration'
@@ -76,26 +76,34 @@ class ExtractedCacheEntryDefinition {
     }
 }
 
+export interface EntryExtractor {
+    restore(listener: CacheListener): Promise<void>
+    extract(listener: CacheListener): Promise<void>
+}
+
 /**
  * Caches and restores the entire Gradle User Home directory, extracting entries containing common artifacts
  * for more efficient storage.
  */
-abstract class AbstractEntryExtractor {
+abstract class AbstractEntryExtractor implements EntryExtractor {
     protected readonly cacheConfig: CacheConfig
     protected readonly gradleUserHome: string
     private extractorName: string
 
     private readonly cacheKeyGenerator: CacheKeyGenerator
+    private readonly cacheAccessor: RemoteCacheAccessor
 
     constructor(
         gradleUserHome: string,
         extractorName: string,
         cacheConfig: CacheConfig,
+        cacheAccessor: RemoteCacheAccessor,
         cacheKeyGenerator: CacheKeyGenerator
     ) {
         this.gradleUserHome = gradleUserHome
         this.extractorName = extractorName
         this.cacheConfig = cacheConfig
+        this.cacheAccessor = cacheAccessor
         this.cacheKeyGenerator = cacheKeyGenerator
     }
 
@@ -140,7 +148,7 @@ abstract class AbstractEntryExtractor {
         pattern: string,
         listener: CacheEntryListener
     ): Promise<ExtractedCacheEntry> {
-        const restoredEntry = await restoreCache(pattern.split('\n'), cacheKey, [], listener)
+        const restoredEntry = await this.cacheAccessor.restoreCache(pattern.split('\n'), cacheKey, [], listener)
         if (restoredEntry) {
             return new ExtractedCacheEntry(artifactType, pattern, cacheKey)
         } else {
@@ -239,7 +247,7 @@ abstract class AbstractEntryExtractor {
             cacheDebug(`No change to previously restored ${artifactType}. Not saving.`)
             entryListener.markNotSaved('contents unchanged')
         } else {
-            await saveCache(pattern.split('\n'), cacheKey, entryListener)
+            await this.cacheAccessor.saveCache(pattern.split('\n'), cacheKey, entryListener)
         }
 
         for (const file of matchingFiles) {
@@ -316,9 +324,10 @@ export class GradleHomeEntryExtractor extends AbstractEntryExtractor {
     constructor(
         gradleUserHome: string,
         cacheConfig: CacheConfig,
-        cacheKeyGenerator: CacheKeyGenerator = new CacheKeyGenerator()
+        cacheAccessor: RemoteCacheAccessor,
+        cacheKeyGenerator: CacheKeyGenerator
     ) {
-        super(gradleUserHome, 'gradle-home', cacheConfig, cacheKeyGenerator)
+        super(gradleUserHome, 'gradle-home', cacheConfig, cacheAccessor, cacheKeyGenerator)
     }
 
     async extract(listener: CacheListener): Promise<void> {
@@ -379,9 +388,10 @@ export class ConfigurationCacheEntryExtractor extends AbstractEntryExtractor {
     constructor(
         gradleUserHome: string,
         cacheConfig: CacheConfig,
-        cacheKeyGenerator: CacheKeyGenerator = new CacheKeyGenerator()
+        cacheAccessor: RemoteCacheAccessor,
+        cacheKeyGenerator: CacheKeyGenerator
     ) {
-        super(gradleUserHome, 'configuration-cache', cacheConfig, cacheKeyGenerator)
+        super(gradleUserHome, 'configuration-cache', cacheConfig, cacheAccessor, cacheKeyGenerator)
     }
 
     /**

--- a/sources/src/caching/gradle-user-home-cache.ts
+++ b/sources/src/caching/gradle-user-home-cache.ts
@@ -6,9 +6,9 @@ import path from 'path'
 import fs from 'fs'
 import {CacheKeyGenerator} from './cache-key'
 import {CacheListener} from './cache-reporting'
-import {saveCache, restoreCache, cacheDebug, isCacheDebuggingEnabled, tryDelete} from './cache-utils'
+import {cacheDebug, isCacheDebuggingEnabled, RemoteCacheAccessor, tryDelete} from './cache-utils'
 import {CacheConfig, ACTION_METADATA_DIR} from '../configuration'
-import {GradleHomeEntryExtractor, ConfigurationCacheEntryExtractor} from './gradle-home-extry-extractor'
+import {GradleHomeEntryExtractor, ConfigurationCacheEntryExtractor, EntryExtractor} from './gradle-home-extry-extractor'
 import {getPredefinedToolchains, mergeToolchainContent, readResourceFileAsString} from './gradle-user-home-utils'
 
 const RESTORED_CACHE_KEY_KEY = 'restored-cache-key'
@@ -23,15 +23,19 @@ export class GradleUserHomeCache {
 
     private readonly cacheKeyGenerator: CacheKeyGenerator
 
+    private readonly cacheAccessor: RemoteCacheAccessor
+
     constructor(
         userHome: string,
         gradleUserHome: string,
         cacheConfig: CacheConfig,
+        cacheAccessor: RemoteCacheAccessor,
         cacheKeyGenerator: CacheKeyGenerator
     ) {
         this.userHome = userHome
         this.gradleUserHome = gradleUserHome
         this.cacheConfig = cacheConfig
+        this.cacheAccessor = cacheAccessor
         this.cacheKeyGenerator = cacheKeyGenerator
     }
 
@@ -69,7 +73,12 @@ export class GradleUserHomeCache {
         )
 
         const cachePath = this.getCachePath()
-        const cacheResult = await restoreCache(cachePath, cacheKey.key, cacheKey.restoreKeys, entryListener)
+        const cacheResult = await this.cacheAccessor.restoreCache(
+            cachePath,
+            cacheKey.key,
+            cacheKey.restoreKeys,
+            entryListener
+        )
         if (!cacheResult) {
             core.info(`${this.cacheDescription} cache not found. Will initialize empty.`)
             return
@@ -89,8 +98,11 @@ export class GradleUserHomeCache {
      */
     async afterRestore(listener: CacheListener): Promise<void> {
         await this.debugReportGradleUserHomeSize('as restored from cache')
-        await new GradleHomeEntryExtractor(this.gradleUserHome, this.cacheConfig).restore(listener)
-        await new ConfigurationCacheEntryExtractor(this.gradleUserHome, this.cacheConfig).restore(listener)
+
+        for (const extractor of this.createExtractors()) {
+            await extractor.restore(listener)
+        }
+
         await this.deleteExcludedPaths()
         await this.debugReportGradleUserHomeSize('after restoring common artifacts')
     }
@@ -128,7 +140,7 @@ export class GradleUserHomeCache {
         }
 
         const cachePath = this.getCachePath()
-        await saveCache(cachePath, cacheKey, gradleHomeEntryListener)
+        await this.cacheAccessor.saveCache(cachePath, cacheKey, gradleHomeEntryListener)
         return
     }
 
@@ -138,10 +150,7 @@ export class GradleUserHomeCache {
     async beforeSave(listener: CacheListener): Promise<void> {
         await this.debugReportGradleUserHomeSize('before saving common artifacts')
         await this.deleteExcludedPaths()
-        await Promise.all([
-            new GradleHomeEntryExtractor(this.gradleUserHome, this.cacheConfig).extract(listener),
-            new ConfigurationCacheEntryExtractor(this.gradleUserHome, this.cacheConfig).extract(listener)
-        ])
+        await Promise.all(this.createExtractors().map(async it => it.extract(listener)))
         await this.debugReportGradleUserHomeSize(
             "after extracting common artifacts (only 'caches' and 'notifications' will be stored)"
         )
@@ -166,6 +175,23 @@ export class GradleUserHomeCache {
                 await tryDelete(toDelete)
             }
         }
+    }
+
+    private createExtractors(): EntryExtractor[] {
+        return [
+            new GradleHomeEntryExtractor(
+                this.gradleUserHome,
+                this.cacheConfig,
+                this.cacheAccessor,
+                this.cacheKeyGenerator
+            ),
+            new ConfigurationCacheEntryExtractor(
+                this.gradleUserHome,
+                this.cacheConfig,
+                this.cacheAccessor,
+                this.cacheKeyGenerator
+            )
+        ]
     }
 
     /**

--- a/sources/test/jest/cache-debug.test.ts
+++ b/sources/test/jest/cache-debug.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs'
 import {GradleUserHomeCache} from "../../src/caching/gradle-user-home-cache"
 import {CacheConfig} from "../../src/configuration"
 import { CacheKeyGenerator } from '../../src/caching/cache-key'
+import { RemoteCacheAccessor } from '../../src/caching/cache-utils'
 
 const testTmp = 'test/jest/tmp'
 fs.rmSync(testTmp, {recursive: true, force: true})
@@ -13,7 +14,7 @@ describe("--info and --stacktrace", () => {
             const emptyGradleHome = `${testTmp}/empty-gradle-home`
             fs.mkdirSync(emptyGradleHome, {recursive: true})
 
-            const stateCache = new GradleUserHomeCache("ignored", emptyGradleHome, new CacheConfig(), new CacheKeyGenerator())
+            const stateCache = new GradleUserHomeCache("ignored", emptyGradleHome, new CacheConfig(), new RemoteCacheAccessor(), new CacheKeyGenerator())
             stateCache.configureInfoLogLevel()
 
             expect(fs.readFileSync(path.resolve(emptyGradleHome, "gradle.properties"), 'utf-8'))
@@ -26,7 +27,7 @@ describe("--info and --stacktrace", () => {
             fs.mkdirSync(existingGradleHome, {recursive: true})
             fs.writeFileSync(path.resolve(existingGradleHome, "gradle.properties"), "org.gradle.logging.level=debug\n")
 
-            const stateCache = new GradleUserHomeCache("ignored", existingGradleHome, new CacheConfig(), new CacheKeyGenerator())
+            const stateCache = new GradleUserHomeCache("ignored", existingGradleHome, new CacheConfig(), new RemoteCacheAccessor(), new CacheKeyGenerator())
             stateCache.configureInfoLogLevel()
 
             expect(fs.readFileSync(path.resolve(existingGradleHome, "gradle.properties"), 'utf-8'))


### PR DESCRIPTION
This enables injection of content later. This is a no-op and has no functional changes.

_Note:_ Ignoring white-space makes this PR much smaller to review. 