### PR TITLE
MultiCI: Abstract state reading

### DIFF
--- a/sources/package-lock.json
+++ b/sources/package-lock.json
@@ -29,7 +29,7 @@
       },
       "devDependencies": {
         "@types/jest": "29.5.14",
-        "@types/node": "20.17.10",
+        "@types/node": "^20.17.12",
         "@types/unzipper": "0.10.10",
         "@types/which": "3.0.4",
         "@typescript-eslint/parser": "7.18.0",
@@ -2380,9 +2380,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.17.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.10.tgz",
-      "integrity": "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==",
+      "version": "20.17.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.12.tgz",
+      "integrity": "sha512-vo/wmBgMIiEA23A/knMfn/cf37VnuF52nZh5ZoW0GWt4e4sxNquibrMRJ7UQsA06+MBx9r/H1jsI9grYjQCQlw==",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -12044,9 +12044,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.17.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.10.tgz",
-      "integrity": "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==",
+      "version": "20.17.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.12.tgz",
+      "integrity": "sha512-vo/wmBgMIiEA23A/knMfn/cf37VnuF52nZh5ZoW0GWt4e4sxNquibrMRJ7UQsA06+MBx9r/H1jsI9grYjQCQlw==",
       "requires": {
         "undici-types": "~6.19.2"
       }

--- a/sources/package.json
+++ b/sources/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.14",
-    "@types/node": "20.17.10",
+    "@types/node": "^20.17.12",
     "@types/unzipper": "0.10.10",
     "@types/which": "3.0.4",
     "@typescript-eslint/parser": "7.18.0",

--- a/sources/src/actions/dependency-submission/main.ts
+++ b/sources/src/actions/dependency-submission/main.ts
@@ -14,7 +14,7 @@ import {
 } from '../../configuration'
 import {saveDeprecationState} from '../../deprecation-collector'
 import {handleMainActionError} from '../../errors'
-import {state} from '../../env/state'
+import {state} from '../../env'
 
 import {configureGithubEnv} from '../github-actions-env'
 configureGithubEnv()

--- a/sources/src/actions/dependency-submission/main.ts
+++ b/sources/src/actions/dependency-submission/main.ts
@@ -1,4 +1,3 @@
-import * as core from '@actions/core'
 import * as setupGradle from '../../setup-gradle'
 import * as gradle from '../../execution/gradle'
 import * as dependencyGraph from '../../dependency-graph'
@@ -15,6 +14,10 @@ import {
 } from '../../configuration'
 import {saveDeprecationState} from '../../deprecation-collector'
 import {handleMainActionError} from '../../errors'
+import {state} from '../../env/state'
+
+import {configureGithubEnv} from '../github-actions-env'
+configureGithubEnv()
 
 /**
  * The main entry point for the action, called by Github Actions for the step.
@@ -59,7 +62,7 @@ export async function run(): Promise<void> {
         await dependencyGraph.complete(config)
 
         // Reset the enabled state of dependency graph
-        core.exportVariable('GITHUB_DEPENDENCY_GRAPH_ENABLED', originallyEnabled)
+        state.exportVariable('GITHUB_DEPENDENCY_GRAPH_ENABLED', originallyEnabled ?? '')
 
         saveDeprecationState()
     } catch (error) {

--- a/sources/src/actions/dependency-submission/post.ts
+++ b/sources/src/actions/dependency-submission/post.ts
@@ -3,6 +3,9 @@ import * as setupGradle from '../../setup-gradle'
 import {CacheConfig, SummaryConfig} from '../../configuration'
 import {handlePostActionError} from '../../errors'
 
+import {configureGithubEnv} from '../github-actions-env'
+configureGithubEnv()
+
 // Catch and log any unhandled exceptions.  These exceptions can leak out of the uploadChunk method in
 // @actions/toolkit when a failed upload closes the file descriptor causing any in-process reads to
 // throw an uncaught exception.  Instead of failing this action, just warn.

--- a/sources/src/actions/github-actions-env.ts
+++ b/sources/src/actions/github-actions-env.ts
@@ -1,0 +1,18 @@
+import * as core from '@actions/core'
+import {state} from '../env/state'
+
+function setupState(): void {
+    state.setImpl({
+        isDebug: core.isDebug,
+        get: core.getState,
+        save: core.saveState,
+        getInput: core.getInput,
+        getMultilineInput: core.getMultilineInput,
+        exportVariable: core.exportVariable,
+        setFailed: core.setFailed
+    })
+}
+
+export const configureGithubEnv = (): void => {
+    setupState()
+}

--- a/sources/src/actions/github-actions-env.ts
+++ b/sources/src/actions/github-actions-env.ts
@@ -1,5 +1,5 @@
 import * as core from '@actions/core'
-import {state} from '../env/state'
+import {state} from '../env'
 
 function setupState(): void {
     state.setImpl({

--- a/sources/src/actions/setup-gradle/main.ts
+++ b/sources/src/actions/setup-gradle/main.ts
@@ -13,6 +13,9 @@ import {
 import {failOnUseOfRemovedFeature, saveDeprecationState} from '../../deprecation-collector'
 import {handleMainActionError} from '../../errors'
 
+import {configureGithubEnv} from '../github-actions-env'
+configureGithubEnv()
+
 /**
  * The main entry point for the action, called by Github Actions for the step.
  */

--- a/sources/src/actions/setup-gradle/post.ts
+++ b/sources/src/actions/setup-gradle/post.ts
@@ -5,6 +5,9 @@ import {CacheConfig, DependencyGraphConfig, SummaryConfig} from '../../configura
 import {handlePostActionError} from '../../errors'
 import {emitDeprecationWarnings, restoreDeprecationState} from '../../deprecation-collector'
 
+import {configureGithubEnv} from '../github-actions-env'
+configureGithubEnv()
+
 // Catch and log any unhandled exceptions.  These exceptions can leak out of the uploadChunk method in
 // @actions/toolkit when a failed upload closes the file descriptor causing any in-process reads to
 // throw an uncaught exception.  Instead of failing this action, just warn.

--- a/sources/src/actions/wrapper-validation/main.ts
+++ b/sources/src/actions/wrapper-validation/main.ts
@@ -2,9 +2,13 @@ import * as path from 'path'
 import * as core from '@actions/core'
 
 import * as validate from '../../wrapper-validation/validate'
+import {state} from '../../env/state'
 import {getActionId, setActionId} from '../../configuration'
 import {failOnUseOfRemovedFeature, emitDeprecationWarnings} from '../../deprecation-collector'
 import {handleMainActionError} from '../../errors'
+
+import {configureGithubEnv} from '../github-actions-env'
+configureGithubEnv()
 
 export async function run(): Promise<void> {
     try {
@@ -18,22 +22,22 @@ export async function run(): Promise<void> {
 
         const result = await validate.findInvalidWrapperJars(
             path.resolve('.'),
-            core.getInput('allow-snapshots') === 'true',
-            core.getInput('allow-checksums').split(',')
+            state.getInput('allow-snapshots') === 'true',
+            state.getInput('allow-checksums').split(',')
         )
         if (result.isValid()) {
             core.info(result.toDisplayString())
 
-            const minWrapperCount = +core.getInput('min-wrapper-count')
+            const minWrapperCount = +state.getInput('min-wrapper-count')
             if (result.valid.length < minWrapperCount) {
                 const message =
                     result.valid.length === 0
                         ? 'Wrapper validation failed: no Gradle Wrapper jars found. Did you forget to checkout the repository?'
                         : `Wrapper validation failed: expected at least ${minWrapperCount} Gradle Wrapper jars, but found ${result.valid.length}.`
-                core.setFailed(message)
+                state.setFailed(message)
             }
         } else {
-            core.setFailed(
+            state.setFailed(
                 `At least one Gradle Wrapper Jar failed validation!\n  See https://github.com/gradle/actions/blob/main/docs/wrapper-validation.md#validation-failures\n${result.toDisplayString()}`
             )
             if (result.invalid.length > 0) {

--- a/sources/src/actions/wrapper-validation/main.ts
+++ b/sources/src/actions/wrapper-validation/main.ts
@@ -2,7 +2,7 @@ import * as path from 'path'
 import * as core from '@actions/core'
 
 import * as validate from '../../wrapper-validation/validate'
-import {state} from '../../env/state'
+import {state} from '../../env'
 import {getActionId, setActionId} from '../../configuration'
 import {failOnUseOfRemovedFeature, emitDeprecationWarnings} from '../../deprecation-collector'
 import {handleMainActionError} from '../../errors'

--- a/sources/src/caching/cache-cleaner.ts
+++ b/sources/src/caching/cache-cleaner.ts
@@ -4,7 +4,7 @@ import * as exec from '@actions/exec'
 import fs from 'fs'
 import path from 'path'
 import * as provisioner from '../execution/provision'
-import {state} from '../env/state'
+import {state} from '../env'
 
 export class CacheCleaner {
     private readonly gradleUserHome: string

--- a/sources/src/caching/cache-cleaner.ts
+++ b/sources/src/caching/cache-cleaner.ts
@@ -4,6 +4,7 @@ import * as exec from '@actions/exec'
 import fs from 'fs'
 import path from 'path'
 import * as provisioner from '../execution/provision'
+import {state} from '../env/state'
 
 export class CacheCleaner {
     private readonly gradleUserHome: string
@@ -17,12 +18,12 @@ export class CacheCleaner {
     async prepare(): Promise<string> {
         // Save the current timestamp
         const timestamp = Date.now().toString()
-        core.saveState('clean-timestamp', timestamp)
+        state.save('clean-timestamp', timestamp)
         return timestamp
     }
 
     async forceCleanup(): Promise<void> {
-        const cleanTimestamp = core.getState('clean-timestamp')
+        const cleanTimestamp = state.get('clean-timestamp')
         await this.forceCleanupFilesOlderThan(cleanTimestamp)
     }
 

--- a/sources/src/env/index.ts
+++ b/sources/src/env/index.ts
@@ -1,1 +1,4 @@
-export {state, CIStateImplementation} from './state'
+import {CIState} from './state'
+
+export {CIStateInputOptions} from './state'
+export const state = new CIState()

--- a/sources/src/env/index.ts
+++ b/sources/src/env/index.ts
@@ -1,0 +1,1 @@
+export {state, CIStateImplementation} from './state'

--- a/sources/src/env/state.ts
+++ b/sources/src/env/state.ts
@@ -1,7 +1,7 @@
 /**
  * Provides read/write access to saving state within the environment.
  */
-export interface GradleEnvStateImplementation {
+export interface CIStateImplementation {
     /**
      * True if this build is being debugged.
      */
@@ -68,10 +68,10 @@ export interface GradleEnvInputOptions {
 /**
  * Provides read/write access to saving state within the environment.
  */
-class GradleEnvState implements GradleEnvStateImplementation {
-    private impl!: GradleEnvStateImplementation
+class CIState implements CIStateImplementation {
+    private impl!: CIStateImplementation
 
-    setImpl(impl: GradleEnvStateImplementation): void {
+    setImpl(impl: CIStateImplementation): void {
         this.impl = impl
     }
 
@@ -135,4 +135,4 @@ class GradleEnvState implements GradleEnvStateImplementation {
     }
 }
 
-export const state = new GradleEnvState()
+export const state = new CIState()

--- a/sources/src/env/state.ts
+++ b/sources/src/env/state.ts
@@ -75,27 +75,62 @@ export class CIState implements CIStateImplementation {
         this.impl = impl
     }
 
+    /**
+     * @inheritdoc
+     */
     isDebug(): boolean {
         return this.impl.isDebug()
     }
 
+    /**
+     * @inheritdoc
+     */
     get(key: string): string {
         return this.impl.get(key)
     }
 
+    /**
+     * @inheritdoc
+     */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     save(key: string, value: any): void {
         this.impl.save(key, value)
     }
 
+    /**
+     * @inheritdoc
+     */
     getInput(key: string, options?: CIStateInputOptions): string {
         return this.impl.getInput(key, options)
     }
 
+    /**
+     * @inheritdoc
+     */
     getMultilineInput(name: string, options?: CIStateInputOptions): string[] {
         return this.impl.getMultilineInput(name, options)
     }
 
+    /**
+     * @inheritdoc
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    exportVariable(name: string, val: any): void {
+        return this.impl.exportVariable(name, val)
+    }
+
+    /**
+     * @inheritdoc
+     */
+    setFailed(message: string | Error): void {
+        return this.impl.setFailed(message)
+    }
+
+    /**
+     * Get's an input if it exists, otherwise returns `undefined`
+     * @param paramName Parameter name to [getInput].
+     * @returns Value stored, or `undefined` if not found.
+     */
     getOptionalInput(paramName: string): string | undefined {
         const paramValue = this.getInput(paramName)
         if (paramValue.length > 0) {
@@ -104,6 +139,12 @@ export class CIState implements CIStateImplementation {
         return undefined
     }
 
+    /**
+     * Gets an input as a boolean value.
+     * @param paramName Parameter name to [getInput].
+     * @param paramDefault Default value returned if not found.
+     * @returns Value stored, or [paramDefault] if not found.
+     */
     getBooleanInput(paramName: string, paramDefault = false): boolean {
         const paramValue = this.getInput(paramName)
         switch (paramValue.toLowerCase().trim()) {
@@ -117,20 +158,16 @@ export class CIState implements CIStateImplementation {
         throw TypeError(`The value '${paramValue} is not valid for '${paramName}. Valid values are: [true, false]`)
     }
 
+    /**
+     * Returns an optional boolean input.
+     * @param paramName Parameter name to [getInput].
+     * @returns The value stored or `undefined` if not found.
+     */
     getOptionalBooleanInput(paramName: string): boolean | undefined {
         const paramValue = this.getInput(paramName)
         if (paramValue === '') {
             return undefined
         }
         return this.getBooleanInput(paramName)
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    exportVariable(name: string, val: any): void {
-        return this.impl.exportVariable(name, val)
-    }
-
-    setFailed(message: string | Error): void {
-        return this.impl.setFailed(message)
     }
 }

--- a/sources/src/env/state.ts
+++ b/sources/src/env/state.ts
@@ -30,7 +30,7 @@ export interface CIStateImplementation {
      * @param options optional. See [GradleEnvInputOptions].
      * @returns The value of the input or `''` if not found.
      */
-    getInput(key: string, options?: GradleEnvInputOptions): string
+    getInput(key: string, options?: CIStateInputOptions): string
 
     /**
      * Gets the values of an multiline input.  Each value is also trimmed.
@@ -39,7 +39,7 @@ export interface CIStateImplementation {
      * @param     options  optional. See [GradleEnvInputOptions].
      * @returns   string[] Values stored, or empty array if not found.
      */
-    getMultilineInput(name: string, options?: GradleEnvInputOptions): string[]
+    getMultilineInput(name: string, options?: CIStateInputOptions): string[]
 
     /**
      * Sets env variable for this action and future actions in the job.
@@ -58,7 +58,7 @@ export interface CIStateImplementation {
     setFailed(message: string | Error): void
 }
 
-export interface GradleEnvInputOptions {
+export interface CIStateInputOptions {
     /**
      * True if input is required.
      */
@@ -68,7 +68,7 @@ export interface GradleEnvInputOptions {
 /**
  * Provides read/write access to saving state within the environment.
  */
-class CIState implements CIStateImplementation {
+export class CIState implements CIStateImplementation {
     private impl!: CIStateImplementation
 
     setImpl(impl: CIStateImplementation): void {
@@ -88,11 +88,11 @@ class CIState implements CIStateImplementation {
         this.impl.save(key, value)
     }
 
-    getInput(key: string, options?: GradleEnvInputOptions): string {
+    getInput(key: string, options?: CIStateInputOptions): string {
         return this.impl.getInput(key, options)
     }
 
-    getMultilineInput(name: string, options?: GradleEnvInputOptions): string[] {
+    getMultilineInput(name: string, options?: CIStateInputOptions): string[] {
         return this.impl.getMultilineInput(name, options)
     }
 
@@ -134,5 +134,3 @@ class CIState implements CIStateImplementation {
         return this.impl.setFailed(message)
     }
 }
-
-export const state = new CIState()

--- a/sources/src/env/state.ts
+++ b/sources/src/env/state.ts
@@ -19,9 +19,10 @@ export interface GradleEnvStateImplementation {
      * Write a persistent value.
      *
      * @param key Property key
-     * @param value Value to store
+     * @param value Value to store, [JSON.stringify] will be called on the value if not a [string].
      */
-    save(key: string, value: string): void
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    save(key: string, value: any): void
 
     /**
      * Read an input parameter from the triggered workflow.
@@ -44,9 +45,10 @@ export interface GradleEnvStateImplementation {
      * Sets env variable for this action and future actions in the job.
      *
      * @param name the name of the variable to set
-     * @param val the value of the variable.
+     * @param val the value of the variable, [JSON.stringify] will be called on the value if not a [string].
      */
-    exportVariable(name: string, val: string): void
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    exportVariable(name: string, val: any): void
 
     /**
      * Sets the action status to failed.
@@ -81,7 +83,8 @@ class GradleEnvState implements GradleEnvStateImplementation {
         return this.impl.get(key)
     }
 
-    save(key: string, value: string): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    save(key: string, value: any): void {
         this.impl.save(key, value)
     }
 
@@ -122,7 +125,8 @@ class GradleEnvState implements GradleEnvStateImplementation {
         return this.getBooleanInput(paramName)
     }
 
-    exportVariable(name: string, val: string): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    exportVariable(name: string, val: any): void {
         return this.impl.exportVariable(name, val)
     }
 

--- a/sources/src/env/state.ts
+++ b/sources/src/env/state.ts
@@ -1,0 +1,134 @@
+/**
+ * Provides read/write access to saving state within the environment.
+ */
+export interface GradleEnvStateImplementation {
+    /**
+     * True if this build is being debugged.
+     */
+    isDebug(): boolean
+
+    /**
+     * Read a persistent value.
+     *
+     * @param key Property key
+     * @returns The value of the property or `''` if not found.
+     */
+    get(key: string): string
+
+    /**
+     * Write a persistent value.
+     *
+     * @param key Property key
+     * @param value Value to store
+     */
+    save(key: string, value: string): void
+
+    /**
+     * Read an input parameter from the triggered workflow.
+     * @param key Input key
+     * @param options optional. See [GradleEnvInputOptions].
+     * @returns The value of the input or `''` if not found.
+     */
+    getInput(key: string, options?: GradleEnvInputOptions): string
+
+    /**
+     * Gets the values of an multiline input.  Each value is also trimmed.
+     *
+     * @param     name     name of the input to get
+     * @param     options  optional. See [GradleEnvInputOptions].
+     * @returns   string[] Values stored, or empty array if not found.
+     */
+    getMultilineInput(name: string, options?: GradleEnvInputOptions): string[]
+
+    /**
+     * Sets env variable for this action and future actions in the job.
+     *
+     * @param name the name of the variable to set
+     * @param val the value of the variable.
+     */
+    exportVariable(name: string, val: string): void
+
+    /**
+     * Sets the action status to failed.
+     * When the action exits it will be with an exit code of 1
+     * @param message add error issue message
+     */
+    setFailed(message: string | Error): void
+}
+
+export interface GradleEnvInputOptions {
+    /**
+     * True if input is required.
+     */
+    readonly required?: boolean
+}
+
+/**
+ * Provides read/write access to saving state within the environment.
+ */
+class GradleEnvState implements GradleEnvStateImplementation {
+    private impl!: GradleEnvStateImplementation
+
+    setImpl(impl: GradleEnvStateImplementation): void {
+        this.impl = impl
+    }
+
+    isDebug(): boolean {
+        return this.impl.isDebug()
+    }
+
+    get(key: string): string {
+        return this.impl.get(key)
+    }
+
+    save(key: string, value: string): void {
+        this.impl.save(key, value)
+    }
+
+    getInput(key: string, options?: GradleEnvInputOptions): string {
+        return this.impl.getInput(key, options)
+    }
+
+    getMultilineInput(name: string, options?: GradleEnvInputOptions): string[] {
+        return this.impl.getMultilineInput(name, options)
+    }
+
+    getOptionalInput(paramName: string): string | undefined {
+        const paramValue = this.getInput(paramName)
+        if (paramValue.length > 0) {
+            return paramValue
+        }
+        return undefined
+    }
+
+    getBooleanInput(paramName: string, paramDefault = false): boolean {
+        const paramValue = this.getInput(paramName)
+        switch (paramValue.toLowerCase().trim()) {
+            case '':
+                return paramDefault
+            case 'false':
+                return false
+            case 'true':
+                return true
+        }
+        throw TypeError(`The value '${paramValue} is not valid for '${paramName}. Valid values are: [true, false]`)
+    }
+
+    getOptionalBooleanInput(paramName: string): boolean | undefined {
+        const paramValue = this.getInput(paramName)
+        if (paramValue === '') {
+            return undefined
+        }
+        return this.getBooleanInput(paramName)
+    }
+
+    exportVariable(name: string, val: string): void {
+        return this.impl.exportVariable(name, val)
+    }
+
+    setFailed(message: string | Error): void {
+        return this.impl.setFailed(message)
+    }
+}
+
+export const state = new GradleEnvState()

--- a/sources/test/jest/cache-cleanup.test.ts
+++ b/sources/test/jest/cache-cleanup.test.ts
@@ -5,6 +5,9 @@ import fs from 'fs'
 import path from 'path'
 import {CacheCleaner} from '../../src/caching/cache-cleaner'
 
+import { configureTestEnv } from './test-env'
+configureTestEnv()
+
 jest.setTimeout(120000)
 
 test('will cleanup unused dependency jars and build-cache entries', async () => {

--- a/sources/test/jest/cache-debug.test.ts
+++ b/sources/test/jest/cache-debug.test.ts
@@ -3,6 +3,9 @@ import * as fs from 'fs'
 import {GradleUserHomeCache} from "../../src/caching/gradle-user-home-cache"
 import {CacheConfig} from "../../src/configuration"
 
+import { configureTestEnv } from './test-env'
+configureTestEnv()
+
 const testTmp = 'test/jest/tmp'
 fs.rmSync(testTmp, {recursive: true, force: true})
 

--- a/sources/test/jest/cache-reporting.test.ts
+++ b/sources/test/jest/cache-reporting.test.ts
@@ -1,5 +1,7 @@
-import exp from 'constants'
 import {CacheEntryListener, CacheListener} from '../../src/caching/cache-reporting'
+
+import { configureTestEnv } from './test-env'
+configureTestEnv()
 
 describe('caching report', () => {
     describe('reports not fully restored', () => {

--- a/sources/test/jest/cache-utils.test.ts
+++ b/sources/test/jest/cache-utils.test.ts
@@ -1,5 +1,8 @@
 import * as cacheUtils from '../../src/caching/cache-utils'
 
+import { configureTestEnv } from './test-env'
+configureTestEnv()
+
 describe('cacheUtils-utils', () => {
     describe('can hash', () => {
         it('a string', async () => {

--- a/sources/test/jest/configuration.test.ts
+++ b/sources/test/jest/configuration.test.ts
@@ -1,5 +1,8 @@
 import * as inputParams from '../../src/configuration'
 
+import { configureTestEnv } from './test-env'
+configureTestEnv()
+
 describe('input params', () => {
     describe('parses numeric input', () => {
         it('uses default value', () => {

--- a/sources/test/jest/dependency-graph.test.ts
+++ b/sources/test/jest/dependency-graph.test.ts
@@ -1,5 +1,8 @@
 import { DependencyGraphConfig } from "../../src/configuration" 
 
+import { configureTestEnv } from './test-env'
+configureTestEnv()
+
 describe('dependency-graph', () => {
     describe('constructs job correlator', () => {
         it('removes commas from workflow name', () => {

--- a/sources/test/jest/gradle-version.test.ts
+++ b/sources/test/jest/gradle-version.test.ts
@@ -1,6 +1,9 @@
 import { describe } from 'node:test'
 import { versionIsAtLeast, parseGradleVersionFromOutput } from '../../src/execution/gradle'
 
+import { configureTestEnv } from './test-env'
+configureTestEnv()
+
 describe('gradle', () => {
     describe('can compare version with', () => {
         it('same version', async () => {

--- a/sources/test/jest/job-summary.test.ts
+++ b/sources/test/jest/job-summary.test.ts
@@ -2,6 +2,9 @@ import { BuildResult } from '../../src/build-results'
 import { renderSummaryTable } from '../../src/job-summary'
 import dedent from 'dedent'
 
+import { configureTestEnv } from './test-env'
+configureTestEnv()
+
 
 const successfulHelpBuild: BuildResult = {
     rootProjectName: 'root',

--- a/sources/test/jest/predefined-toolchains.test.ts
+++ b/sources/test/jest/predefined-toolchains.test.ts
@@ -1,5 +1,8 @@
 import {getPredefinedToolchains, mergeToolchainContent} from "../../src/caching/gradle-user-home-utils";
 
+import { configureTestEnv } from './test-env'
+configureTestEnv()
+
 describe('predefined-toolchains', () => {
     const OLD_ENV = process.env
     afterAll(() => {

--- a/sources/test/jest/short-lived-token.test.ts
+++ b/sources/test/jest/short-lived-token.test.ts
@@ -1,6 +1,9 @@
 import {DevelocityAccessCredentials, getToken} from "../../src/develocity/short-lived-token";
 import nock from "nock";
 
+import { configureTestEnv } from './test-env'
+configureTestEnv()
+
 describe('short lived tokens', () => {
     it('parse valid access key should return an object', async () => {
         let develocityAccessCredentials = DevelocityAccessCredentials.parse('some-host.local=key1;host2=key2');

--- a/sources/test/jest/test-env.ts
+++ b/sources/test/jest/test-env.ts
@@ -1,0 +1,54 @@
+import { state, GradleEnvStateImplementation } from '../../src/env/state'
+
+class TestStateImplementation implements GradleEnvStateImplementation {
+    readonly state: Record<string, string> = {}
+
+    readonly inputs: Record<string, string> = {}
+
+    readonly env: Record<string, string> = {}
+
+    _isDebug = false
+
+    isDebug(): boolean {
+        return this._isDebug
+    }
+    
+    get(key: string): string {
+        return this.state[key] ?? ''
+    }
+
+    save(key: string, value: string): void {
+        this.state[key] = value
+    }
+
+    getInput(key: string): string {
+        return this.inputs[key] ?? ''
+    }
+
+    setInput(key: string, value: string) {
+        this.inputs[key] = value
+    }
+
+    getMultilineInput(name: string): string[] {
+        const input = this.inputs[name]
+        return input?.split('\n') ?? []
+    }
+
+    exportVariable(name: string, value: string): void {
+        process.env[name] = value
+    }
+
+    setFailed(message: string | Error): void {
+        throw new Error(message.toString())
+    }
+}
+
+const testState = new TestStateImplementation()
+
+function setupState(): void {
+    state.setImpl(testState)
+}
+
+export const configureTestEnv = (): void => {
+    setupState()
+}

--- a/sources/test/jest/test-env.ts
+++ b/sources/test/jest/test-env.ts
@@ -1,6 +1,7 @@
-import { state, GradleEnvStateImplementation } from '../../src/env/state'
+import { state } from '../../src/env'
+import { CIStateImplementation } from '../../src/env/state'
 
-class TestStateImplementation implements GradleEnvStateImplementation {
+class TestStateImplementation implements CIStateImplementation {
     readonly state: Record<string, string> = {}
 
     readonly inputs: Record<string, string> = {}

--- a/sources/test/jest/wrapper-validation/checksums.test.ts
+++ b/sources/test/jest/wrapper-validation/checksums.test.ts
@@ -2,6 +2,9 @@ import * as checksums from '../../../src/wrapper-validation/checksums'
 import nock from 'nock'
 import {afterEach, describe, expect, test, jest} from '@jest/globals'
 
+import { configureTestEnv } from '../test-env'
+configureTestEnv()
+
 jest.setTimeout(60000)
 
 const CHECKSUM_8_1 = 'ed2c26eba7cfb93cc2b7785d05e534f07b5b48b5e7fc941921cd098628abca58'

--- a/sources/test/jest/wrapper-validation/find.test.ts
+++ b/sources/test/jest/wrapper-validation/find.test.ts
@@ -2,6 +2,9 @@ import * as path from 'path'
 import * as find from '../../../src/wrapper-validation/find'
 import {expect, test} from '@jest/globals'
 
+import { configureTestEnv } from '../test-env'
+configureTestEnv()
+
 test('finds test data wrapper jars', async () => {
   const repoRoot = path.resolve('./test/jest/wrapper-validation')
   const wrapperJars = await find.findWrapperJars(repoRoot)

--- a/sources/test/jest/wrapper-validation/hash.test.ts
+++ b/sources/test/jest/wrapper-validation/hash.test.ts
@@ -2,6 +2,9 @@ import * as path from 'path'
 import * as hash from '../../../src/wrapper-validation/hash'
 import {expect, test} from '@jest/globals'
 
+import { configureTestEnv } from '../test-env'
+configureTestEnv()
+
 test('can sha256 files', async () => {
   const sha = await hash.sha256File(
     path.resolve('test/jest/wrapper-validation/data/invalid/gradle-wrapper.jar')

--- a/sources/test/jest/wrapper-validation/validate.test.ts
+++ b/sources/test/jest/wrapper-validation/validate.test.ts
@@ -4,7 +4,9 @@ import * as validate from '../../../src/wrapper-validation/validate'
 import {expect, test, jest} from '@jest/globals'
 import { WrapperChecksums, KNOWN_CHECKSUMS } from '../../../src/wrapper-validation/checksums'
 import { ChecksumCache } from '../../../src/wrapper-validation/cache'
-import exp from 'constants'
+
+import { configureTestEnv } from '../test-env'
+configureTestEnv()
 
 jest.setTimeout(30000)
 


### PR DESCRIPTION
There is no functional changes present, access is moved behind small wrapper class to provide a simple abstraction to be replaced. 

Currently, we implement this in terms of `Github Actions` -- for obvious reasons. In the future, this enables implementation in other, non-Github CI environments. 

#22 contains all usages replaced directly.

Part of gradle/actions#502.