### PR TITLE
MultiCI: Abstract Logging into type per env

### DIFF
--- a/sources/package-lock.json
+++ b/sources/package-lock.json
@@ -29,7 +29,7 @@
       },
       "devDependencies": {
         "@types/jest": "29.5.14",
-        "@types/node": "20.17.10",
+        "@types/node": "^20.17.12",
         "@types/unzipper": "0.10.10",
         "@types/which": "3.0.4",
         "@typescript-eslint/parser": "7.18.0",
@@ -2380,9 +2380,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.17.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.10.tgz",
-      "integrity": "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==",
+      "version": "20.17.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.12.tgz",
+      "integrity": "sha512-vo/wmBgMIiEA23A/knMfn/cf37VnuF52nZh5ZoW0GWt4e4sxNquibrMRJ7UQsA06+MBx9r/H1jsI9grYjQCQlw==",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -12044,9 +12044,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.17.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.10.tgz",
-      "integrity": "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==",
+      "version": "20.17.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.12.tgz",
+      "integrity": "sha512-vo/wmBgMIiEA23A/knMfn/cf37VnuF52nZh5ZoW0GWt4e4sxNquibrMRJ7UQsA06+MBx9r/H1jsI9grYjQCQlw==",
       "requires": {
         "undici-types": "~6.19.2"
       }

--- a/sources/package.json
+++ b/sources/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.14",
-    "@types/node": "20.17.10",
+    "@types/node": "^20.17.12",
     "@types/unzipper": "0.10.10",
     "@types/which": "3.0.4",
     "@typescript-eslint/parser": "7.18.0",

--- a/sources/src/actions/dependency-submission/main.ts
+++ b/sources/src/actions/dependency-submission/main.ts
@@ -16,6 +16,9 @@ import {saveDeprecationState} from '../../deprecation-collector'
 import {handleMainActionError} from '../../errors'
 import {state} from '../../env/state'
 
+import {configureGithubEnv} from '../github-actions-env'
+configureGithubEnv()
+
 /**
  * The main entry point for the action, called by Github Actions for the step.
  */

--- a/sources/src/actions/dependency-submission/main.ts
+++ b/sources/src/actions/dependency-submission/main.ts
@@ -1,4 +1,3 @@
-import * as core from '@actions/core'
 import * as setupGradle from '../../setup-gradle'
 import * as gradle from '../../execution/gradle'
 import * as dependencyGraph from '../../dependency-graph'
@@ -15,6 +14,7 @@ import {
 } from '../../configuration'
 import {saveDeprecationState} from '../../deprecation-collector'
 import {handleMainActionError} from '../../errors'
+import {state} from '../../env/state'
 
 /**
  * The main entry point for the action, called by Github Actions for the step.
@@ -59,7 +59,7 @@ export async function run(): Promise<void> {
         await dependencyGraph.complete(config)
 
         // Reset the enabled state of dependency graph
-        core.exportVariable('GITHUB_DEPENDENCY_GRAPH_ENABLED', originallyEnabled)
+        state.exportVariable('GITHUB_DEPENDENCY_GRAPH_ENABLED', originallyEnabled ?? '')
 
         saveDeprecationState()
     } catch (error) {

--- a/sources/src/actions/dependency-submission/post.ts
+++ b/sources/src/actions/dependency-submission/post.ts
@@ -3,6 +3,9 @@ import * as setupGradle from '../../setup-gradle'
 import {CacheConfig, SummaryConfig} from '../../configuration'
 import {handlePostActionError} from '../../errors'
 
+import {configureGithubEnv} from '../github-actions-env'
+configureGithubEnv()
+
 // Catch and log any unhandled exceptions.  These exceptions can leak out of the uploadChunk method in
 // @actions/toolkit when a failed upload closes the file descriptor causing any in-process reads to
 // throw an uncaught exception.  Instead of failing this action, just warn.

--- a/sources/src/actions/github-actions-env.ts
+++ b/sources/src/actions/github-actions-env.ts
@@ -1,0 +1,18 @@
+import * as core from '@actions/core'
+import {state} from '../env/state'
+
+function setupState(): void {
+    state.setImpl({
+        isDebug: core.isDebug,
+        get: core.getState,
+        set: core.saveState,
+        getInput: core.getInput,
+        getMultilineInput: core.getMultilineInput,
+        exportVariable: core.exportVariable,
+        setFailed: core.setFailed
+    })
+}
+
+export const configureGithubEnv = (): void => {
+    setupState()
+}

--- a/sources/src/actions/github-actions-env.ts
+++ b/sources/src/actions/github-actions-env.ts
@@ -1,5 +1,6 @@
 import * as core from '@actions/core'
 import {state} from '../env/state'
+import {log, LogLevel} from '../env/logging'
 
 function setupState(): void {
     state.setImpl({
@@ -13,6 +14,27 @@ function setupState(): void {
     })
 }
 
+function setupLogger(): void {
+    // Redirect the log output to the GitHub Actions logging system.
+    log.setWriter((level, message) => {
+        switch (level) {
+            case LogLevel.DEBUG:
+                log.debug(message)
+                break
+            case LogLevel.INFO:
+                log.info(message)
+                break
+            case LogLevel.WARN:
+                log.warn(message)
+                break
+            case LogLevel.ERROR:
+                core.error(message)
+                break
+        }
+    })
+}
+
 export const configureGithubEnv = (): void => {
     setupState()
+    setupLogger()
 }

--- a/sources/src/actions/setup-gradle/main.ts
+++ b/sources/src/actions/setup-gradle/main.ts
@@ -13,6 +13,9 @@ import {
 import {failOnUseOfRemovedFeature, saveDeprecationState} from '../../deprecation-collector'
 import {handleMainActionError} from '../../errors'
 
+import {configureGithubEnv} from '../github-actions-env'
+configureGithubEnv()
+
 /**
  * The main entry point for the action, called by Github Actions for the step.
  */

--- a/sources/src/actions/setup-gradle/post.ts
+++ b/sources/src/actions/setup-gradle/post.ts
@@ -5,6 +5,9 @@ import {CacheConfig, DependencyGraphConfig, SummaryConfig} from '../../configura
 import {handlePostActionError} from '../../errors'
 import {emitDeprecationWarnings, restoreDeprecationState} from '../../deprecation-collector'
 
+import {configureGithubEnv} from '../github-actions-env'
+configureGithubEnv()
+
 // Catch and log any unhandled exceptions.  These exceptions can leak out of the uploadChunk method in
 // @actions/toolkit when a failed upload closes the file descriptor causing any in-process reads to
 // throw an uncaught exception.  Instead of failing this action, just warn.

--- a/sources/src/actions/wrapper-validation/main.ts
+++ b/sources/src/actions/wrapper-validation/main.ts
@@ -7,6 +7,9 @@ import {getActionId, setActionId} from '../../configuration'
 import {failOnUseOfRemovedFeature, emitDeprecationWarnings} from '../../deprecation-collector'
 import {handleMainActionError} from '../../errors'
 
+import {configureGithubEnv} from '../github-actions-env'
+configureGithubEnv()
+
 export async function run(): Promise<void> {
     try {
         if (getActionId() === 'gradle/wrapper-validation-action') {

--- a/sources/src/actions/wrapper-validation/main.ts
+++ b/sources/src/actions/wrapper-validation/main.ts
@@ -2,6 +2,7 @@ import * as path from 'path'
 import * as core from '@actions/core'
 
 import * as validate from '../../wrapper-validation/validate'
+import {state} from '../../env/state'
 import {getActionId, setActionId} from '../../configuration'
 import {failOnUseOfRemovedFeature, emitDeprecationWarnings} from '../../deprecation-collector'
 import {handleMainActionError} from '../../errors'
@@ -18,22 +19,22 @@ export async function run(): Promise<void> {
 
         const result = await validate.findInvalidWrapperJars(
             path.resolve('.'),
-            core.getInput('allow-snapshots') === 'true',
-            core.getInput('allow-checksums').split(',')
+            state.getInput('allow-snapshots') === 'true',
+            state.getInput('allow-checksums').split(',')
         )
         if (result.isValid()) {
             core.info(result.toDisplayString())
 
-            const minWrapperCount = +core.getInput('min-wrapper-count')
+            const minWrapperCount = +state.getInput('min-wrapper-count')
             if (result.valid.length < minWrapperCount) {
                 const message =
                     result.valid.length === 0
                         ? 'Wrapper validation failed: no Gradle Wrapper jars found. Did you forget to checkout the repository?'
                         : `Wrapper validation failed: expected at least ${minWrapperCount} Gradle Wrapper jars, but found ${result.valid.length}.`
-                core.setFailed(message)
+                state.setFailed(message)
             }
         } else {
-            core.setFailed(
+            state.setFailed(
                 `At least one Gradle Wrapper Jar failed validation!\n  See https://github.com/gradle/actions/blob/main/docs/wrapper-validation.md#validation-failures\n${result.toDisplayString()}`
             )
             if (result.invalid.length > 0) {

--- a/sources/src/actions/wrapper-validation/main.ts
+++ b/sources/src/actions/wrapper-validation/main.ts
@@ -2,6 +2,7 @@ import * as path from 'path'
 import * as core from '@actions/core'
 
 import * as validate from '../../wrapper-validation/validate'
+import {log} from '../../env/logging'
 import {state} from '../../env/state'
 import {getActionId, setActionId} from '../../configuration'
 import {failOnUseOfRemovedFeature, emitDeprecationWarnings} from '../../deprecation-collector'
@@ -26,7 +27,7 @@ export async function run(): Promise<void> {
             state.getInput('allow-checksums').split(',')
         )
         if (result.isValid()) {
-            core.info(result.toDisplayString())
+            log.info(result.toDisplayString())
 
             const minWrapperCount = +state.getInput('min-wrapper-count')
             if (result.valid.length < minWrapperCount) {

--- a/sources/src/caching/cache-cleaner.ts
+++ b/sources/src/caching/cache-cleaner.ts
@@ -4,6 +4,7 @@ import * as exec from '@actions/exec'
 import fs from 'fs'
 import path from 'path'
 import * as provisioner from '../execution/provision'
+import {log} from '../env/logging'
 import {state} from '../env/state'
 
 export class CacheCleaner {
@@ -60,7 +61,7 @@ export class CacheCleaner {
         const executable = await provisioner.provisionGradleAtLeast('8.12')
 
         await core.group('Executing Gradle to clean up caches', async () => {
-            core.info(`Cleaning up caches last used before ${cleanTimestamp}`)
+            log.info(`Cleaning up caches last used before ${cleanTimestamp}`)
             await this.executeCleanupBuild(executable, cleanupProjectDir)
         })
     }

--- a/sources/src/caching/cache-cleaner.ts
+++ b/sources/src/caching/cache-cleaner.ts
@@ -4,6 +4,7 @@ import * as exec from '@actions/exec'
 import fs from 'fs'
 import path from 'path'
 import * as provisioner from '../execution/provision'
+import {state} from '../env/state'
 
 export class CacheCleaner {
     private readonly gradleUserHome: string
@@ -17,12 +18,12 @@ export class CacheCleaner {
     async prepare(): Promise<string> {
         // Save the current timestamp
         const timestamp = Date.now().toString()
-        core.saveState('clean-timestamp', timestamp)
+        state.set('clean-timestamp', timestamp)
         return timestamp
     }
 
     async forceCleanup(): Promise<void> {
-        const cleanTimestamp = core.getState('clean-timestamp')
+        const cleanTimestamp = state.get('clean-timestamp')
         await this.forceCleanupFilesOlderThan(cleanTimestamp)
     }
 

--- a/sources/src/caching/cache-utils.ts
+++ b/sources/src/caching/cache-utils.ts
@@ -6,13 +6,14 @@ import * as crypto from 'crypto'
 import * as path from 'path'
 import * as fs from 'fs'
 
+import {state} from '../env/state'
 import {CacheEntryListener} from './cache-reporting'
 
 const SEGMENT_DOWNLOAD_TIMEOUT_VAR = 'SEGMENT_DOWNLOAD_TIMEOUT_MINS'
 const SEGMENT_DOWNLOAD_TIMEOUT_DEFAULT = 10 * 60 * 1000 // 10 minutes
 
 export function isCacheDebuggingEnabled(): boolean {
-    if (core.isDebug()) {
+    if (state.isDebug()) {
         return true
     }
     return process.env['GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED'] ? true : false

--- a/sources/src/caching/cache-utils.ts
+++ b/sources/src/caching/cache-utils.ts
@@ -1,4 +1,3 @@
-import * as core from '@actions/core'
 import * as cache from '@actions/cache'
 import * as exec from '@actions/exec'
 
@@ -6,18 +5,11 @@ import * as crypto from 'crypto'
 import * as path from 'path'
 import * as fs from 'fs'
 
-import {state} from '../env/state'
+import {log} from '../env/logging'
 import {CacheEntryListener} from './cache-reporting'
 
 const SEGMENT_DOWNLOAD_TIMEOUT_VAR = 'SEGMENT_DOWNLOAD_TIMEOUT_MINS'
 const SEGMENT_DOWNLOAD_TIMEOUT_DEFAULT = 10 * 60 * 1000 // 10 minutes
-
-export function isCacheDebuggingEnabled(): boolean {
-    if (state.isDebug()) {
-        return true
-    }
-    return process.env['GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED'] ? true : false
-}
 
 export function hashFileNames(fileNames: string[]): string {
     return hashStrings(fileNames.map(x => x.replace(new RegExp(`\\${path.sep}`, 'g'), '/')))
@@ -48,7 +40,7 @@ export async function restoreCache(
         if (restoredEntry !== undefined) {
             const restoreTime = Date.now() - startTime
             listener.markRestored(restoredEntry.key, restoredEntry.size, restoreTime)
-            core.info(`Restored cache entry with key ${cacheKey} to ${cachePath.join()} in ${restoreTime}ms`)
+            log.info(`Restored cache entry with key ${cacheKey} to ${cachePath.join()} in ${restoreTime}ms`)
         }
         return restoredEntry
     } catch (error) {
@@ -64,7 +56,7 @@ export async function saveCache(cachePath: string[], cacheKey: string, listener:
         const savedEntry = await cache.saveCache(cachePath, cacheKey)
         const saveTime = Date.now() - startTime
         listener.markSaved(savedEntry.key, savedEntry.size, saveTime)
-        core.info(`Saved cache entry with key ${cacheKey} from ${cachePath.join()} in ${saveTime}ms`)
+        log.info(`Saved cache entry with key ${cacheKey} from ${cachePath.join()} in ${saveTime}ms`)
     } catch (error) {
         if (error instanceof cache.ReserveCacheError) {
             listener.markAlreadyExists(cacheKey)
@@ -75,14 +67,6 @@ export async function saveCache(cachePath: string[], cacheKey: string, listener:
     }
 }
 
-export function cacheDebug(message: string): void {
-    if (isCacheDebuggingEnabled()) {
-        core.info(message)
-    } else {
-        core.debug(message)
-    }
-}
-
 export function handleCacheFailure(error: unknown, message: string): void {
     if (error instanceof cache.ValidationError) {
         // Fail on cache validation errors
@@ -90,12 +74,12 @@ export function handleCacheFailure(error: unknown, message: string): void {
     }
     if (error instanceof cache.ReserveCacheError) {
         // Reserve cache errors are expected if the artifact has been previously cached
-        core.info(`${message}: ${error}`)
+        log.info(`${message}: ${error}`)
     } else {
         // Warn on all other errors
-        core.warning(`${message}: ${error}`)
+        log.warn(`${message}: ${error}`)
         if (error instanceof Error && error.stack) {
-            cacheDebug(error.stack)
+            log.cacheDebug(error.stack)
         }
     }
 }
@@ -119,12 +103,12 @@ export async function tryDelete(file: string): Promise<void> {
             return
         } catch (error) {
             if (attempt === maxAttempts) {
-                core.warning(`Failed to delete ${file}, which will impact caching. 
+                log.warn(`Failed to delete ${file}, which will impact caching. 
 It is likely locked by another process. Output of 'jps -ml':
 ${await getJavaProcesses()}`)
                 throw error
             } else {
-                cacheDebug(`Attempt to delete ${file} failed. Will try again.`)
+                log.cacheDebug(`Attempt to delete ${file} failed. Will try again.`)
                 await delay(1000)
             }
         }

--- a/sources/src/caching/caches.ts
+++ b/sources/src/caching/caches.ts
@@ -10,6 +10,7 @@ import {CacheCleaner} from './cache-cleaner'
 import {DaemonController} from '../daemon-controller'
 import {CacheConfig} from '../configuration'
 import {BuildResults} from '../build-results'
+import {log} from '../env/logging'
 import {state} from '../env/state'
 
 const CACHE_RESTORED_VAR = 'GRADLE_BUILD_ACTION_CACHE_RESTORED'
@@ -22,7 +23,7 @@ export async function restore(
 ): Promise<void> {
     // Bypass restore cache on all but first action step in workflow.
     if (process.env[CACHE_RESTORED_VAR]) {
-        core.info('Cache only restored on first action step.')
+        log.info('Cache only restored on first action step.')
         return
     }
     state.exportVariable(CACHE_RESTORED_VAR, true.toString())
@@ -30,7 +31,7 @@ export async function restore(
     const gradleStateCache = new GradleUserHomeCache(userHome, gradleUserHome, cacheConfig)
 
     if (cacheConfig.isCacheDisabled()) {
-        core.info('Cache is disabled: will not restore state from previous builds.')
+        log.info('Cache is disabled: will not restore state from previous builds.')
         // Initialize the Gradle User Home even when caching is disabled.
         gradleStateCache.init()
         cacheListener.setDisabled()
@@ -39,13 +40,13 @@ export async function restore(
 
     if (gradleStateCache.cacheOutputExists()) {
         if (!cacheConfig.isCacheOverwriteExisting()) {
-            core.info('Gradle User Home already exists: will not restore from cache.')
+            log.info('Gradle User Home already exists: will not restore from cache.')
             // Initialize pre-existing Gradle User Home.
             gradleStateCache.init()
             cacheListener.setDisabled(EXISTING_GRADLE_HOME)
             return
         }
-        core.info('Gradle User Home already exists: will overwrite with cached contents.')
+        log.info('Gradle User Home already exists: will overwrite with cached contents.')
     }
 
     gradleStateCache.init()
@@ -53,13 +54,13 @@ export async function restore(
     state.set(CACHE_RESTORED_VAR, true.toString())
 
     if (cacheConfig.isCacheCleanupEnabled()) {
-        core.info('Preparing cache for cleanup.')
+        log.info('Preparing cache for cleanup.')
         const cacheCleaner = new CacheCleaner(gradleUserHome, process.env['RUNNER_TEMP']!)
         await cacheCleaner.prepare()
     }
 
     if (cacheConfig.isCacheWriteOnly()) {
-        core.info('Cache is write-only: will not restore from cache.')
+        log.info('Cache is write-only: will not restore from cache.')
         cacheListener.setWriteOnly()
         return
     }
@@ -78,17 +79,17 @@ export async function save(
     cacheConfig: CacheConfig
 ): Promise<void> {
     if (cacheConfig.isCacheDisabled()) {
-        core.info('Cache is disabled: will not save state for later builds.')
+        log.info('Cache is disabled: will not save state for later builds.')
         return
     }
 
     if (!state.get(CACHE_RESTORED_VAR)) {
-        core.info('Cache will not be saved: not restored in main action step.')
+        log.info('Cache will not be saved: not restored in main action step.')
         return
     }
 
     if (cacheConfig.isCacheReadOnly()) {
-        core.info('Cache is read-only: will not save state for use in subsequent builds.')
+        log.info('Cache is read-only: will not save state for use in subsequent builds.')
         cacheListener.setReadOnly()
         return
     }
@@ -99,13 +100,13 @@ export async function save(
 
     if (cacheConfig.isCacheCleanupEnabled()) {
         if (buildResults.anyConfigCacheHit()) {
-            core.info('Not performing cache-cleanup due to config-cache reuse')
+            log.info('Not performing cache-cleanup due to config-cache reuse')
             cacheListener.setCacheCleanupDisabled(CLEANUP_DISABLED_DUE_TO_CONFIG_CACHE_HIT)
         } else if (cacheConfig.shouldPerformCacheCleanup(buildResults.anyFailed())) {
             cacheListener.setCacheCleanupEnabled()
             await performCacheCleanup(gradleUserHome)
         } else {
-            core.info('Not performing cache-cleanup due to build failure')
+            log.info('Not performing cache-cleanup due to build failure')
             cacheListener.setCacheCleanupDisabled(CLEANUP_DISABLED_DUE_TO_FAILURE)
         }
     }
@@ -120,6 +121,6 @@ async function performCacheCleanup(gradleUserHome: string): Promise<void> {
     try {
         await cacheCleaner.forceCleanup()
     } catch (e) {
-        core.warning(`Cache cleanup failed. Will continue. ${String(e)}`)
+        log.warn(`Cache cleanup failed. Will continue. ${String(e)}`)
     }
 }

--- a/sources/src/caching/caches.ts
+++ b/sources/src/caching/caches.ts
@@ -10,6 +10,7 @@ import {CacheCleaner} from './cache-cleaner'
 import {DaemonController} from '../daemon-controller'
 import {CacheConfig} from '../configuration'
 import {BuildResults} from '../build-results'
+import {state} from '../env/state'
 
 const CACHE_RESTORED_VAR = 'GRADLE_BUILD_ACTION_CACHE_RESTORED'
 
@@ -24,7 +25,7 @@ export async function restore(
         core.info('Cache only restored on first action step.')
         return
     }
-    core.exportVariable(CACHE_RESTORED_VAR, true)
+    state.exportVariable(CACHE_RESTORED_VAR, true.toString())
 
     const gradleStateCache = new GradleUserHomeCache(userHome, gradleUserHome, cacheConfig)
 
@@ -49,7 +50,7 @@ export async function restore(
 
     gradleStateCache.init()
     // Mark the state as restored so that post-action will perform save.
-    core.saveState(CACHE_RESTORED_VAR, true)
+    state.set(CACHE_RESTORED_VAR, true.toString())
 
     if (cacheConfig.isCacheCleanupEnabled()) {
         core.info('Preparing cache for cleanup.')
@@ -81,7 +82,7 @@ export async function save(
         return
     }
 
-    if (!core.getState(CACHE_RESTORED_VAR)) {
+    if (!state.get(CACHE_RESTORED_VAR)) {
         core.info('Cache will not be saved: not restored in main action step.')
         return
     }

--- a/sources/src/caching/gradle-home-extry-extractor.ts
+++ b/sources/src/caching/gradle-home-extry-extractor.ts
@@ -1,11 +1,12 @@
 import path from 'path'
 import fs from 'fs'
-import * as core from '@actions/core'
 import * as glob from '@actions/glob'
 
 import {CacheEntryListener, CacheListener} from './cache-reporting'
-import {cacheDebug, hashFileNames, isCacheDebuggingEnabled, restoreCache, saveCache, tryDelete} from './cache-utils'
+import {hashFileNames, restoreCache, saveCache, tryDelete} from './cache-utils'
 
+import {log} from '../env/logging'
+import {state} from '../env/state'
 import {BuildResult, loadBuildResults} from '../build-results'
 import {CacheConfig, ACTION_METADATA_DIR} from '../configuration'
 import {getCacheKeyBase} from './cache-key'
@@ -107,7 +108,7 @@ abstract class AbstractEntryExtractor {
             // Handle case where the extracted-cache-entry definitions have been changed
             const skipRestore = process.env[SKIP_RESTORE_VAR] || ''
             if (skipRestore.includes(artifactType)) {
-                core.info(`Not restoring extracted cache entry for ${artifactType}`)
+                log.info(`Not restoring extracted cache entry for ${artifactType}`)
                 entryListener.markRequested('SKIP_RESTORE')
             } else {
                 processes.push(
@@ -136,7 +137,7 @@ abstract class AbstractEntryExtractor {
         if (restoredEntry) {
             return new ExtractedCacheEntry(artifactType, pattern, cacheKey)
         } else {
-            core.info(`Did not restore ${artifactType} with key ${cacheKey} to ${pattern}`)
+            log.info(`Did not restore ${artifactType} with key ${cacheKey} to ${pattern}`)
             return new ExtractedCacheEntry(artifactType, pattern, undefined)
         }
     }
@@ -148,7 +149,7 @@ abstract class AbstractEntryExtractor {
     async extract(listener: CacheListener): Promise<void> {
         // Load the cache entry definitions (from config) and the previously restored entries (from persisted metadata file)
         const cacheEntryDefinitions = this.getExtractedCacheEntryDefinitions()
-        cacheDebug(
+        log.cacheDebug(
             `Extracting cache entries for ${this.extractorName}: ${JSON.stringify(cacheEntryDefinitions, null, 2)}`
         )
 
@@ -172,7 +173,7 @@ abstract class AbstractEntryExtractor {
             const matchingFiles = await globber.glob()
 
             if (matchingFiles.length === 0) {
-                cacheDebug(`No files found to cache for ${artifactType}`)
+                log.cacheDebug(`No files found to cache for ${artifactType}`)
                 continue
             }
 
@@ -228,7 +229,7 @@ abstract class AbstractEntryExtractor {
         )?.cacheKey
 
         if (previouslyRestoredKey === cacheKey) {
-            cacheDebug(`No change to previously restored ${artifactType}. Not saving.`)
+            log.cacheDebug(`No change to previously restored ${artifactType}. Not saving.`)
             entryListener.markNotSaved('contents unchanged')
         } else {
             await saveCache(pattern.split('\n'), cacheKey, entryListener)
@@ -245,7 +246,7 @@ abstract class AbstractEntryExtractor {
         const relativeFiles = files.map(x => path.relative(this.gradleUserHome, x))
         const key = hashFileNames(relativeFiles)
 
-        cacheDebug(`Generating cache key for ${artifactType} from file names: ${relativeFiles}`)
+        log.cacheDebug(`Generating cache key for ${artifactType} from file names: ${relativeFiles}`)
 
         return `${getCacheKeyBase(artifactType, CACHE_PROTOCOL_VERSION)}-${key}`
     }
@@ -253,14 +254,14 @@ abstract class AbstractEntryExtractor {
     protected async createCacheKeyFromFileContents(artifactType: string, pattern: string): Promise<string> {
         const key = await glob.hashFiles(pattern)
 
-        cacheDebug(`Generating cache key for ${artifactType} from files matching: ${pattern}`)
+        log.cacheDebug(`Generating cache key for ${artifactType} from files matching: ${pattern}`)
 
         return `${getCacheKeyBase(artifactType, CACHE_PROTOCOL_VERSION)}-${key}`
     }
 
     // Run actions sequentially if debugging is enabled
     private async awaitForDebugging(p: Promise<ExtractedCacheEntry>): Promise<ExtractedCacheEntry> {
-        if (isCacheDebuggingEnabled()) {
+        if (state.isCacheDebuggingEnabled()) {
             await p
         }
         return p
@@ -276,7 +277,7 @@ abstract class AbstractEntryExtractor {
         }
 
         const filedata = fs.readFileSync(cacheMetadataFile, 'utf-8')
-        cacheDebug(`Loaded cache metadata for ${this.extractorName}: ${filedata}`)
+        log.cacheDebug(`Loaded cache metadata for ${this.extractorName}: ${filedata}`)
         const extractedCacheEntryMetadata = JSON.parse(filedata) as ExtractedCacheEntryMetadata
         return extractedCacheEntryMetadata.entries
     }
@@ -289,7 +290,7 @@ abstract class AbstractEntryExtractor {
         extractedCacheEntryMetadata.entries = results.filter(x => x.cacheKey !== undefined)
 
         const filedata = JSON.stringify(extractedCacheEntryMetadata)
-        cacheDebug(`Saving cache metadata for ${this.extractorName}: ${filedata}`)
+        log.cacheDebug(`Saving cache metadata for ${this.extractorName}: ${filedata}`)
 
         fs.writeFileSync(this.getCacheMetadataFile(), filedata, 'utf-8')
     }
@@ -325,7 +326,7 @@ export class GradleHomeEntryExtractor extends AbstractEntryExtractor {
         })
 
         for (const wrapperZip of await globber.glob()) {
-            cacheDebug(`Deleting wrapper zip: ${wrapperZip}`)
+            log.cacheDebug(`Deleting wrapper zip: ${wrapperZip}`)
             await tryDelete(wrapperZip)
         }
     }
@@ -389,7 +390,7 @@ export class ConfigurationCacheEntryExtractor extends AbstractEntryExtractor {
     private markNotRestored(listener: CacheListener, reason: string): void {
         const cacheEntries = this.loadExtractedCacheEntries()
         if (cacheEntries.length > 0) {
-            core.info(`Not restoring configuration-cache state, as ${reason}`)
+            log.info(`Not restoring configuration-cache state, as ${reason}`)
             for (const cacheEntry of cacheEntries) {
                 listener.entry(cacheEntry.pattern).markNotRestored(reason)
             }
@@ -403,7 +404,7 @@ export class ConfigurationCacheEntryExtractor extends AbstractEntryExtractor {
         if (!this.cacheConfig.getCacheEncryptionKey()) {
             const cacheEntryDefinitions = this.getExtractedCacheEntryDefinitions()
             if (cacheEntryDefinitions.length > 0) {
-                core.info('Not saving configuration-cache state, as no encryption key was provided')
+                log.info('Not saving configuration-cache state, as no encryption key was provided')
                 for (const cacheEntry of cacheEntryDefinitions) {
                     listener.entry(cacheEntry.pattern).markNotSaved('No encryption key provided')
                 }
@@ -435,7 +436,7 @@ export class ConfigurationCacheEntryExtractor extends AbstractEntryExtractor {
                     return !versionIsAtLeast(result.gradleVersion, '8.6.0')
                 })
             ) {
-                core.info(
+                log.info(
                     `Not saving config-cache data for ${configCachePath}. Configuration cache data is only saved for Gradle 8.6+`
                 )
                 definition.notCacheableBecause('Configuration cache data only saved for Gradle 8.6+')

--- a/sources/src/caching/gradle-user-home-cache.ts
+++ b/sources/src/caching/gradle-user-home-cache.ts
@@ -1,4 +1,3 @@
-import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import * as glob from '@actions/glob'
 
@@ -6,10 +5,11 @@ import path from 'path'
 import fs from 'fs'
 import {generateCacheKey} from './cache-key'
 import {CacheListener} from './cache-reporting'
-import {saveCache, restoreCache, cacheDebug, isCacheDebuggingEnabled, tryDelete} from './cache-utils'
+import {saveCache, restoreCache, tryDelete} from './cache-utils'
 import {CacheConfig, ACTION_METADATA_DIR} from '../configuration'
 import {GradleHomeEntryExtractor, ConfigurationCacheEntryExtractor} from './gradle-home-extry-extractor'
 import {getPredefinedToolchains, mergeToolchainContent, readResourceFileAsString} from './gradle-user-home-utils'
+import {log} from '../env/logging'
 import {state} from '../env/state'
 
 const RESTORED_CACHE_KEY_KEY = 'restored-cache-key'
@@ -41,7 +41,7 @@ export class GradleUserHomeCache {
     cacheOutputExists(): boolean {
         const cachesDir = path.resolve(this.gradleUserHome, 'caches')
         if (fs.existsSync(cachesDir)) {
-            cacheDebug(`Cache output exists at ${cachesDir}`)
+            log.cacheDebug(`Cache output exists at ${cachesDir}`)
             return true
         }
         return false
@@ -55,7 +55,7 @@ export class GradleUserHomeCache {
 
         const cacheKey = generateCacheKey(this.cacheName, this.cacheConfig)
 
-        cacheDebug(
+        log.cacheDebug(
             `Requesting ${this.cacheDescription} with
     key:${cacheKey.key}
     restoreKeys:[${cacheKey.restoreKeys}]`
@@ -64,7 +64,7 @@ export class GradleUserHomeCache {
         const cachePath = this.getCachePath()
         const cacheResult = await restoreCache(cachePath, cacheKey.key, cacheKey.restoreKeys, entryListener)
         if (!cacheResult) {
-            core.info(`${this.cacheDescription} cache not found. Will initialize empty.`)
+            log.info(`${this.cacheDescription} cache not found. Will initialize empty.`)
             return
         }
 
@@ -73,7 +73,7 @@ export class GradleUserHomeCache {
         try {
             await this.afterRestore(listener)
         } catch (error) {
-            core.warning(`Restore ${this.cacheDescription} failed in 'afterRestore': ${error}`)
+            log.warn(`Restore ${this.cacheDescription} failed in 'afterRestore': ${error}`)
         }
     }
 
@@ -101,7 +101,7 @@ export class GradleUserHomeCache {
         const gradleHomeEntryListener = listener.entry(this.cacheDescription)
 
         if (restoredCacheKey && cacheKey === restoredCacheKey) {
-            core.info(`Cache hit occurred on the cache key ${cacheKey}, not saving cache.`)
+            log.info(`Cache hit occurred on the cache key ${cacheKey}, not saving cache.`)
 
             for (const entryListener of listener.cacheEntries) {
                 if (entryListener === gradleHomeEntryListener) {
@@ -116,7 +116,7 @@ export class GradleUserHomeCache {
         try {
             await this.beforeSave(listener)
         } catch (error) {
-            core.warning(`Save ${this.cacheDescription} failed in 'beforeSave': ${error}`)
+            log.warn(`Save ${this.cacheDescription} failed in 'beforeSave': ${error}`)
             return
         }
 
@@ -149,13 +149,13 @@ export class GradleUserHomeCache {
         const resolvedPaths = rawPaths.map(x => path.resolve(this.gradleUserHome, x))
 
         for (const p of resolvedPaths) {
-            cacheDebug(`Removing excluded path: ${p}`)
+            log.cacheDebug(`Removing excluded path: ${p}`)
             const globber = await glob.create(p, {
                 implicitDescendants: false
             })
 
             for (const toDelete of await globber.glob()) {
-                cacheDebug(`Removing excluded file: ${toDelete}`)
+                log.cacheDebug(`Removing excluded file: ${toDelete}`)
                 await tryDelete(toDelete)
             }
         }
@@ -170,7 +170,7 @@ export class GradleUserHomeCache {
         const rawPaths: string[] = this.cacheConfig.getCacheIncludes()
         rawPaths.push(ACTION_METADATA_DIR)
         const resolvedPaths = rawPaths.map(x => this.resolveCachePath(x))
-        cacheDebug(`Using cache paths: ${resolvedPaths}`)
+        log.cacheDebug(`Using cache paths: ${resolvedPaths}`)
         return resolvedPaths
     }
 
@@ -226,14 +226,14 @@ export class GradleUserHomeCache {
             fs.mkdirSync(m2dir, {recursive: true})
             fs.writeFileSync(toolchainXmlTarget, preInstalledToolchains)
 
-            core.info(`Wrote default JDK locations to ${toolchainXmlTarget}`)
+            log.info(`Wrote default JDK locations to ${toolchainXmlTarget}`)
         } else {
             // Merge into an existing toolchains.xml file
             const existingToolchainContent = fs.readFileSync(toolchainXmlTarget, 'utf8')
             const mergedContent = mergeToolchainContent(existingToolchainContent, preInstalledToolchains)
 
             fs.writeFileSync(toolchainXmlTarget, mergedContent)
-            core.info(`Merged default JDK locations into ${toolchainXmlTarget}`)
+            log.info(`Merged default JDK locations into ${toolchainXmlTarget}`)
         }
     }
 
@@ -247,11 +247,11 @@ export class GradleUserHomeCache {
         const infoProperties = `org.gradle.logging.level=info\norg.gradle.logging.stacktrace=all\n`
         const propertiesFile = path.resolve(this.gradleUserHome, 'gradle.properties')
         if (fs.existsSync(propertiesFile)) {
-            core.info(`Merged --info and --stacktrace into existing ${propertiesFile} file`)
+            log.info(`Merged --info and --stacktrace into existing ${propertiesFile} file`)
             const existingProperties = fs.readFileSync(propertiesFile, 'utf-8')
             fs.writeFileSync(propertiesFile, `${infoProperties}\n${existingProperties}`)
         } else {
-            core.info(`Created a new ${propertiesFile} with --info and --stacktrace`)
+            log.info(`Created a new ${propertiesFile} with --info and --stacktrace`)
             fs.writeFileSync(propertiesFile, infoProperties)
         }
     }
@@ -261,7 +261,7 @@ export class GradleUserHomeCache {
      * this method will give a detailed report of the Gradle User Home contents.
      */
     private async debugReportGradleUserHomeSize(label: string): Promise<void> {
-        if (!isCacheDebuggingEnabled() && !state.isDebug()) {
+        if (!state.isCacheDebuggingEnabled() && !state.isDebug()) {
             return
         }
         if (!fs.existsSync(this.gradleUserHome)) {
@@ -273,9 +273,9 @@ export class GradleUserHomeCache {
             ignoreReturnCode: true
         })
 
-        core.info(`Gradle User Home (directories >5M): ${label}`)
+        log.info(`Gradle User Home (directories >5M): ${label}`)
 
-        core.info(
+        log.info(
             result.stdout
                 .trimEnd()
                 .replace(/\t/g, '    ')
@@ -286,6 +286,6 @@ export class GradleUserHomeCache {
                 .join('\n')
         )
 
-        core.info('-----------------------')
+        log.info('-----------------------')
     }
 }

--- a/sources/src/caching/gradle-user-home-cache.ts
+++ b/sources/src/caching/gradle-user-home-cache.ts
@@ -10,6 +10,7 @@ import {saveCache, restoreCache, cacheDebug, isCacheDebuggingEnabled, tryDelete}
 import {CacheConfig, ACTION_METADATA_DIR} from '../configuration'
 import {GradleHomeEntryExtractor, ConfigurationCacheEntryExtractor} from './gradle-home-extry-extractor'
 import {getPredefinedToolchains, mergeToolchainContent, readResourceFileAsString} from './gradle-user-home-utils'
+import {state} from '../env/state'
 
 const RESTORED_CACHE_KEY_KEY = 'restored-cache-key'
 
@@ -33,7 +34,7 @@ export class GradleUserHomeCache {
         // Export the GRADLE_ENCRYPTION_KEY variable if provided
         const encryptionKey = this.cacheConfig.getCacheEncryptionKey()
         if (encryptionKey) {
-            core.exportVariable('GRADLE_ENCRYPTION_KEY', encryptionKey)
+            state.exportVariable('GRADLE_ENCRYPTION_KEY', encryptionKey)
         }
     }
 
@@ -67,7 +68,7 @@ export class GradleUserHomeCache {
             return
         }
 
-        core.saveState(RESTORED_CACHE_KEY_KEY, cacheResult.key)
+        state.set(RESTORED_CACHE_KEY_KEY, cacheResult.key)
 
         try {
             await this.afterRestore(listener)
@@ -96,7 +97,7 @@ export class GradleUserHomeCache {
      */
     async save(listener: CacheListener): Promise<void> {
         const cacheKey = generateCacheKey(this.cacheName, this.cacheConfig).key
-        const restoredCacheKey = core.getState(RESTORED_CACHE_KEY_KEY)
+        const restoredCacheKey = state.get(RESTORED_CACHE_KEY_KEY)
         const gradleHomeEntryListener = listener.entry(this.cacheDescription)
 
         if (restoredCacheKey && cacheKey === restoredCacheKey) {
@@ -191,7 +192,7 @@ export class GradleUserHomeCache {
         // Copy the default toolchain definitions to `~/.m2/toolchains.xml`
         this.registerToolchains()
 
-        if (core.isDebug()) {
+        if (state.isDebug()) {
             this.configureInfoLogLevel()
         }
     }
@@ -260,7 +261,7 @@ export class GradleUserHomeCache {
      * this method will give a detailed report of the Gradle User Home contents.
      */
     private async debugReportGradleUserHomeSize(label: string): Promise<void> {
-        if (!isCacheDebuggingEnabled() && !core.isDebug()) {
+        if (!isCacheDebuggingEnabled() && !state.isDebug()) {
             return
         }
         if (!fs.existsSync(this.gradleUserHome)) {

--- a/sources/src/configuration.ts
+++ b/sources/src/configuration.ts
@@ -3,6 +3,7 @@ import * as github from '@actions/github'
 import * as cache from '@actions/cache'
 import * as deprecator from './deprecation-collector'
 import {SUMMARY_ENV_VAR} from '@actions/core/lib/summary'
+import {state} from './env/state'
 
 import path from 'path'
 
@@ -12,7 +13,7 @@ export const ACTION_METADATA_DIR = '.setup-gradle'
 
 export class DependencyGraphConfig {
     getDependencyGraphOption(): DependencyGraphOption {
-        const val = core.getInput('dependency-graph')
+        const val = state.getInput('dependency-graph')
         switch (val.toLowerCase().trim()) {
             case 'disabled':
                 return DependencyGraphOption.Disabled
@@ -35,7 +36,7 @@ export class DependencyGraphConfig {
     }
 
     getArtifactRetentionDays(): number {
-        const val = core.getInput('artifact-retention-days')
+        const val = state.getInput('artifact-retention-days')
         return parseNumericInput('artifact-retention-days', val, 0)
         // Zero indicates that the default repository settings should be used
     }
@@ -45,7 +46,7 @@ export class DependencyGraphConfig {
     }
 
     getReportDirectory(): string {
-        const param = core.getInput('dependency-graph-report-dir')
+        const param = state.getInput('dependency-graph-report-dir')
         return path.resolve(getWorkspaceDirectory(), param)
     }
 
@@ -153,7 +154,7 @@ export class CacheConfig {
             return legacyVal ? CacheCleanupOption.Always : CacheCleanupOption.Never
         }
 
-        const val = core.getInput('cache-cleanup')
+        const val = state.getInput('cache-cleanup')
         switch (val.toLowerCase().trim()) {
             case 'always':
                 return CacheCleanupOption.Always
@@ -168,15 +169,15 @@ export class CacheConfig {
     }
 
     getCacheEncryptionKey(): string {
-        return core.getInput('cache-encryption-key')
+        return state.getInput('cache-encryption-key')
     }
 
     getCacheIncludes(): string[] {
-        return core.getMultilineInput('gradle-home-cache-includes')
+        return state.getMultilineInput('gradle-home-cache-includes')
     }
 
     getCacheExcludes(): string[] {
-        return core.getMultilineInput('gradle-home-cache-excludes')
+        return state.getMultilineInput('gradle-home-cache-excludes')
     }
 }
 
@@ -220,7 +221,7 @@ export class SummaryConfig {
     }
 
     private parseJobSummaryOption(paramName: string): JobSummaryOption {
-        const val = core.getInput(paramName)
+        const val = state.getInput(paramName)
         switch (val.toLowerCase().trim()) {
             case 'never':
                 return JobSummaryOption.Never
@@ -250,16 +251,16 @@ export class BuildScanConfig {
     }
 
     getBuildScanTermsOfUseUrl(): string {
-        return core.getInput('build-scan-terms-of-use-url')
+        return state.getInput('build-scan-terms-of-use-url')
     }
 
     getBuildScanTermsOfUseAgree(): string {
-        return core.getInput('build-scan-terms-of-use-agree')
+        return state.getInput('build-scan-terms-of-use-agree')
     }
 
     getDevelocityAccessKey(): string {
         return (
-            core.getInput('develocity-access-key') ||
+            state.getInput('develocity-access-key') ||
             process.env[BuildScanConfig.DevelocityAccessKeyEnvVar] ||
             process.env[BuildScanConfig.GradleEnterpriseAccessKeyEnvVar] ||
             ''
@@ -267,7 +268,7 @@ export class BuildScanConfig {
     }
 
     getDevelocityTokenExpiry(): string {
-        return core.getInput('develocity-token-expiry')
+        return state.getInput('develocity-token-expiry')
     }
 
     getDevelocityInjectionEnabled(): boolean | undefined {
@@ -275,7 +276,7 @@ export class BuildScanConfig {
     }
 
     getDevelocityUrl(): string {
-        return core.getInput('develocity-url')
+        return state.getInput('develocity-url')
     }
 
     getDevelocityAllowUntrustedServer(): boolean | undefined {
@@ -291,23 +292,23 @@ export class BuildScanConfig {
     }
 
     getDevelocityPluginVersion(): string {
-        return core.getInput('develocity-plugin-version')
+        return state.getInput('develocity-plugin-version')
     }
 
     getDevelocityCcudPluginVersion(): string {
-        return core.getInput('develocity-ccud-plugin-version')
+        return state.getInput('develocity-ccud-plugin-version')
     }
 
     getGradlePluginRepositoryUrl(): string {
-        return core.getInput('gradle-plugin-repository-url')
+        return state.getInput('gradle-plugin-repository-url')
     }
 
     getGradlePluginRepositoryUsername(): string {
-        return core.getInput('gradle-plugin-repository-username')
+        return state.getInput('gradle-plugin-repository-username')
     }
 
     getGradlePluginRepositoryPassword(): string {
-        return core.getInput('gradle-plugin-repository-password')
+        return state.getInput('gradle-plugin-repository-password')
     }
 
     private verifyTermsOfUseAgreement(): boolean {
@@ -327,12 +328,12 @@ export class BuildScanConfig {
 
 export class GradleExecutionConfig {
     getGradleVersion(): string {
-        return core.getInput('gradle-version')
+        return state.getInput('gradle-version')
     }
 
     getBuildRootDirectory(): string {
         const baseDirectory = getWorkspaceDirectory()
-        const buildRootDirectoryInput = core.getInput('build-root-directory')
+        const buildRootDirectoryInput = state.getInput('build-root-directory')
         const resolvedBuildRootDirectory =
             buildRootDirectoryInput === ''
                 ? path.resolve(baseDirectory)
@@ -341,15 +342,15 @@ export class GradleExecutionConfig {
     }
 
     getDependencyResolutionTask(): string {
-        return core.getInput('dependency-resolution-task') || ':ForceDependencyResolutionPlugin_resolveAllDependencies'
+        return state.getInput('dependency-resolution-task') || ':ForceDependencyResolutionPlugin_resolveAllDependencies'
     }
 
     getAdditionalArguments(): string {
-        return core.getInput('additional-arguments')
+        return state.getInput('additional-arguments')
     }
 
     verifyNoArguments(): void {
-        const input = core.getInput('arguments')
+        const input = state.getInput('arguments')
         if (input.length !== 0) {
             deprecator.failOnUseOfRemovedFeature(
                 `The 'arguments' parameter is no longer supported for ${getActionId()}`,
@@ -371,11 +372,11 @@ export class WrapperValidationConfig {
 
 // Internal parameters
 export function getJobMatrix(): string {
-    return core.getInput('workflow-job-context')
+    return state.getInput('workflow-job-context')
 }
 
 export function getGithubToken(): string {
-    return core.getInput('github-token', {required: true})
+    return state.getInput('github-token', {required: true})
 }
 
 export function getWorkspaceDirectory(): string {
@@ -387,7 +388,7 @@ export function getActionId(): string | undefined {
 }
 
 export function setActionId(id: string): void {
-    core.exportVariable(ACTION_ID_VAR, id)
+    state.exportVariable(ACTION_ID_VAR, id)
 }
 
 export function parseNumericInput(paramName: string, paramValue: string, paramDefault: number): number {
@@ -402,7 +403,7 @@ export function parseNumericInput(paramName: string, paramValue: string, paramDe
 }
 
 function getOptionalInput(paramName: string): string | undefined {
-    const paramValue = core.getInput(paramName)
+    const paramValue = state.getInput(paramName)
     if (paramValue.length > 0) {
         return paramValue
     }
@@ -410,7 +411,7 @@ function getOptionalInput(paramName: string): string | undefined {
 }
 
 function getBooleanInput(paramName: string, paramDefault = false): boolean {
-    const paramValue = core.getInput(paramName)
+    const paramValue = state.getInput(paramName)
     switch (paramValue.toLowerCase().trim()) {
         case '':
             return paramDefault
@@ -423,7 +424,7 @@ function getBooleanInput(paramName: string, paramDefault = false): boolean {
 }
 
 function getOptionalBooleanInput(paramName: string): boolean | undefined {
-    const paramValue = core.getInput(paramName)
+    const paramValue = state.getInput(paramName)
     if (paramValue === '') {
         return undefined
     }

--- a/sources/src/configuration.ts
+++ b/sources/src/configuration.ts
@@ -1,8 +1,8 @@
-import * as core from '@actions/core'
 import * as github from '@actions/github'
 import * as cache from '@actions/cache'
 import * as deprecator from './deprecation-collector'
 import {SUMMARY_ENV_VAR} from '@actions/core/lib/summary'
+import {log} from './env/logging'
 import {state} from './env/state'
 
 import path from 'path'
@@ -77,7 +77,7 @@ export class DependencyGraphConfig {
     }
 
     private static describeMatrix(matrixJson: string): string {
-        core.debug(`Got matrix json: ${matrixJson}`)
+        log.debug(`Got matrix json: ${matrixJson}`)
         const matrix = JSON.parse(matrixJson)
         if (matrix) {
             return Object.values(matrix).join('-')
@@ -317,7 +317,7 @@ export class BuildScanConfig {
                 this.getBuildScanTermsOfUseUrl() !== 'https://gradle.com/help/legal-terms-of-use') ||
             this.getBuildScanTermsOfUseAgree() !== 'yes'
         ) {
-            core.warning(
+            log.warn(
                 `Terms of use at 'https://gradle.com/help/legal-terms-of-use' must be agreed in order to publish build scans.`
             )
             return false

--- a/sources/src/daemon-controller.ts
+++ b/sources/src/daemon-controller.ts
@@ -1,8 +1,8 @@
-import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import * as fs from 'fs'
 import * as path from 'path'
 import {BuildResults} from './build-results'
+import {log} from './env/logging'
 
 export class DaemonController {
     private readonly gradleHomes
@@ -18,10 +18,10 @@ export class DaemonController {
         for (const gradleHome of this.gradleHomes) {
             const executable = path.resolve(gradleHome, 'bin', 'gradle')
             if (!fs.existsSync(executable)) {
-                core.warning(`Gradle executable not found at ${executable}. Could not stop Gradle daemons.`)
+                log.warn(`Gradle executable not found at ${executable}. Could not stop Gradle daemons.`)
                 continue
             }
-            core.info(`Stopping Gradle daemons for ${gradleHome}`)
+            log.info(`Stopping Gradle daemons for ${gradleHome}`)
             executions.push(
                 exec.exec(executable, args, {
                     ignoreReturnCode: true

--- a/sources/src/dependency-graph.ts
+++ b/sources/src/dependency-graph.ts
@@ -11,6 +11,7 @@ import fs from 'fs'
 
 import {JobFailure} from './errors'
 import {DependencyGraphConfig, DependencyGraphOption, getGithubToken, getWorkspaceDirectory} from './configuration'
+import {log} from './env/logging'
 import {state} from './env/state'
 
 const DEPENDENCY_GRAPH_PREFIX = 'dependency-graph_'
@@ -28,7 +29,7 @@ export async function setup(config: DependencyGraphConfig): Promise<void> {
         return
     }
 
-    core.info('Enabling dependency graph generation')
+    log.info('Enabling dependency graph generation')
     state.exportVariable('GITHUB_DEPENDENCY_GRAPH_ENABLED', 'true')
     maybeExportVariable('GITHUB_DEPENDENCY_GRAPH_CONTINUE_ON_FAILURE', config.getDependencyGraphContinueOnFailure())
     maybeExportVariable('GITHUB_DEPENDENCY_GRAPH_JOB_CORRELATOR', config.getJobCorrelator())
@@ -73,7 +74,7 @@ export async function complete(config: DependencyGraphConfig): Promise<void> {
 
 async function downloadAndSubmitDependencyGraphs(config: DependencyGraphConfig): Promise<void> {
     if (isRunningInActEnvironment()) {
-        core.info('Dependency graph not supported in the ACT environment.')
+        log.info('Dependency graph not supported in the ACT environment.')
         return
     }
 
@@ -86,7 +87,7 @@ async function downloadAndSubmitDependencyGraphs(config: DependencyGraphConfig):
 
 async function findAndSubmitDependencyGraphs(config: DependencyGraphConfig): Promise<void> {
     if (isRunningInActEnvironment()) {
-        core.info('Dependency graph not supported in the ACT environment.')
+        log.info('Dependency graph not supported in the ACT environment.')
         return
     }
 
@@ -97,7 +98,7 @@ async function findAndSubmitDependencyGraphs(config: DependencyGraphConfig): Pro
         try {
             await uploadDependencyGraphs(dependencyGraphFiles, config)
         } catch (uploadError) {
-            core.info(String(uploadError))
+            log.info(String(uploadError))
         }
         throw e
     }
@@ -105,7 +106,7 @@ async function findAndSubmitDependencyGraphs(config: DependencyGraphConfig): Pro
 
 async function findAndUploadDependencyGraphs(config: DependencyGraphConfig): Promise<void> {
     if (isRunningInActEnvironment()) {
-        core.info('Dependency graph not supported in the ACT environment.')
+        log.info('Dependency graph not supported in the ACT environment.')
         return
     }
 
@@ -133,7 +134,7 @@ async function downloadDependencyGraphs(config: DependencyGraphConfig): Promise<
 
     const artifactName = config.getDownloadArtifactName()
     if (artifactName) {
-        core.info(`Filtering for artifacts ending with ${artifactName}`)
+        log.info(`Filtering for artifacts ending with ${artifactName}`)
         dependencyGraphArtifacts = dependencyGraphArtifacts.filter(artifact => artifact.name.includes(artifactName))
     }
 
@@ -141,7 +142,7 @@ async function downloadDependencyGraphs(config: DependencyGraphConfig): Promise<
         const downloadedArtifact = await artifactClient.downloadArtifact(artifact.id, {
             findBy
         })
-        core.info(`Downloading dependency-graph artifact ${artifact.name} to ${downloadedArtifact.downloadPath}`)
+        log.info(`Downloading dependency-graph artifact ${artifact.name} to ${downloadedArtifact.downloadPath}`)
     }
 
     return findDependencyGraphFiles()
@@ -152,13 +153,13 @@ async function findDependencyGraphFiles(): Promise<string[]> {
     const allFiles = await globber.glob()
     const unprocessedFiles = allFiles.filter(file => !isProcessed(file))
     unprocessedFiles.forEach(markProcessed)
-    core.info(`Found dependency graph files: ${unprocessedFiles.join(', ')}`)
+    log.info(`Found dependency graph files: ${unprocessedFiles.join(', ')}`)
     return unprocessedFiles
 }
 
 async function uploadDependencyGraphs(dependencyGraphFiles: string[], config: DependencyGraphConfig): Promise<void> {
     if (dependencyGraphFiles.length === 0) {
-        core.info('No dependency graph files found to upload.')
+        log.info('No dependency graph files found to upload.')
         return
     }
 
@@ -167,7 +168,7 @@ async function uploadDependencyGraphs(dependencyGraphFiles: string[], config: De
     const artifactClient = new DefaultArtifactClient()
     for (const dependencyGraphFile of dependencyGraphFiles) {
         const relativePath = getRelativePathFromWorkspace(dependencyGraphFile)
-        core.info(`Uploading dependency graph file: ${relativePath}`)
+        log.info(`Uploading dependency graph file: ${relativePath}`)
         const artifactName = `${DEPENDENCY_GRAPH_PREFIX}${path.basename(dependencyGraphFile)}`
         await artifactClient.uploadArtifact(artifactName, [dependencyGraphFile], workspaceDirectory, {
             retentionDays: config.getArtifactRetentionDays()
@@ -177,7 +178,7 @@ async function uploadDependencyGraphs(dependencyGraphFiles: string[], config: De
 
 async function submitDependencyGraphs(dependencyGraphFiles: string[]): Promise<void> {
     if (dependencyGraphFiles.length === 0) {
-        core.info('No dependency graph files found to submit.')
+        log.info('No dependency graph files found to submit.')
         return
     }
 
@@ -236,7 +237,7 @@ function warnOrFail(config: DependencyGraphConfig, option: String, error: unknow
         throw new JobFailure(error)
     }
 
-    core.warning(`Failed to ${option} dependency graph. Will continue.\n${String(error)}`)
+    log.warn(`Failed to ${option} dependency graph. Will continue.\n${String(error)}`)
 }
 
 function getOctokit(): InstanceType<typeof GitHub> {

--- a/sources/src/dependency-graph.ts
+++ b/sources/src/dependency-graph.ts
@@ -11,13 +11,14 @@ import fs from 'fs'
 
 import {JobFailure} from './errors'
 import {DependencyGraphConfig, DependencyGraphOption, getGithubToken, getWorkspaceDirectory} from './configuration'
+import {state} from './env/state'
 
 const DEPENDENCY_GRAPH_PREFIX = 'dependency-graph_'
 
 export async function setup(config: DependencyGraphConfig): Promise<void> {
     const option = config.getDependencyGraphOption()
     if (option === DependencyGraphOption.Disabled) {
-        core.exportVariable('GITHUB_DEPENDENCY_GRAPH_ENABLED', 'false')
+        state.exportVariable('GITHUB_DEPENDENCY_GRAPH_ENABLED', 'false')
         return
     }
     // Download and submit early, for compatability with dependency review.
@@ -28,7 +29,7 @@ export async function setup(config: DependencyGraphConfig): Promise<void> {
     }
 
     core.info('Enabling dependency graph generation')
-    core.exportVariable('GITHUB_DEPENDENCY_GRAPH_ENABLED', 'true')
+    state.exportVariable('GITHUB_DEPENDENCY_GRAPH_ENABLED', 'true')
     maybeExportVariable('GITHUB_DEPENDENCY_GRAPH_CONTINUE_ON_FAILURE', config.getDependencyGraphContinueOnFailure())
     maybeExportVariable('GITHUB_DEPENDENCY_GRAPH_JOB_CORRELATOR', config.getJobCorrelator())
     maybeExportVariable('GITHUB_DEPENDENCY_GRAPH_JOB_ID', github.context.runId.toString())
@@ -46,7 +47,7 @@ export async function setup(config: DependencyGraphConfig): Promise<void> {
 function maybeExportVariable(variableName: string, value: string | boolean | undefined): void {
     if (!process.env[variableName]) {
         if (value !== undefined) {
-            core.exportVariable(variableName, value)
+            state.exportVariable(variableName, JSON.stringify(value))
         }
     }
 }

--- a/sources/src/deprecation-collector.ts
+++ b/sources/src/deprecation-collector.ts
@@ -1,5 +1,6 @@
 import * as core from '@actions/core'
 import {getActionId} from './configuration'
+import {state} from './env/state'
 
 const DEPRECATION_UPGRADE_PAGE = 'https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md'
 const recordedDeprecations: Deprecation[] = []
@@ -27,7 +28,7 @@ export function failOnUseOfRemovedFeature(removalMessage: string, deprecationMes
     const deprecation = new Deprecation(deprecationMessage)
     const errorMessage = `${removalMessage}.\nSee ${deprecation.getDocumentationLink()}`
     recordedErrors.push(errorMessage)
-    core.setFailed(errorMessage)
+    state.setFailed(errorMessage)
 }
 
 export function getDeprecations(): Deprecation[] {
@@ -50,12 +51,12 @@ export function emitDeprecationWarnings(hasJobSummary = true): void {
 }
 
 export function saveDeprecationState(): void {
-    core.saveState('deprecation-collector_deprecations', JSON.stringify(recordedDeprecations))
-    core.saveState('deprecation-collector_errors', JSON.stringify(recordedErrors))
+    state.set('deprecation-collector_deprecations', JSON.stringify(recordedDeprecations))
+    state.set('deprecation-collector_errors', JSON.stringify(recordedErrors))
 }
 
 export function restoreDeprecationState(): void {
-    const savedDeprecations = core.getState('deprecation-collector_deprecations')
+    const savedDeprecations = state.get('deprecation-collector_deprecations')
     if (savedDeprecations) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         JSON.parse(savedDeprecations).forEach((obj: any) => {
@@ -63,7 +64,7 @@ export function restoreDeprecationState(): void {
         })
     }
 
-    const savedErrors = core.getState('deprecation-collector_errors')
+    const savedErrors = state.get('deprecation-collector_errors')
     if (savedErrors) {
         recordedErrors.push(...JSON.parse(savedErrors))
     }

--- a/sources/src/deprecation-collector.ts
+++ b/sources/src/deprecation-collector.ts
@@ -1,5 +1,5 @@
-import * as core from '@actions/core'
 import {getActionId} from './configuration'
+import {log} from './env/logging'
 import {state} from './env/state'
 
 const DEPRECATION_UPGRADE_PAGE = 'https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md'
@@ -41,11 +41,11 @@ export function getErrors(): string[] {
 
 export function emitDeprecationWarnings(hasJobSummary = true): void {
     if (recordedDeprecations.length > 0) {
-        core.warning(
+        log.warn(
             `This job uses deprecated functionality from the '${getActionId()}' action. Consult the ${hasJobSummary ? 'Job Summary' : 'logs'} for more details.`
         )
         for (const deprecation of recordedDeprecations) {
-            core.info(`DEPRECATION: ${deprecation.message}. See ${deprecation.getDocumentationLink()}`)
+            log.info(`DEPRECATION: ${deprecation.message}. See ${deprecation.getDocumentationLink()}`)
         }
     }
 }

--- a/sources/src/develocity/build-scan.ts
+++ b/sources/src/develocity/build-scan.ts
@@ -1,6 +1,6 @@
-import * as core from '@actions/core'
 import {BuildScanConfig} from '../configuration'
 import {setupToken} from './short-lived-token'
+import {state} from '../env/state'
 
 export async function setup(config: BuildScanConfig): Promise<void> {
     maybeExportVariable('DEVELOCITY_INJECTION_INIT_SCRIPT_NAME', 'gradle-actions.inject-develocity.init.gradle')
@@ -33,7 +33,7 @@ export async function setup(config: BuildScanConfig): Promise<void> {
 
 function maybeExportVariable(variableName: string, value: unknown): void {
     if (!process.env[variableName]) {
-        core.exportVariable(variableName, value)
+        state.exportVariable(variableName, JSON.stringify(value))
     }
 }
 

--- a/sources/src/develocity/short-lived-token.ts
+++ b/sources/src/develocity/short-lived-token.ts
@@ -2,15 +2,16 @@ import * as httpm from 'typed-rest-client/HttpClient'
 import * as core from '@actions/core'
 import {BuildScanConfig} from '../configuration'
 import {recordDeprecation} from '../deprecation-collector'
+import {log} from '../env/logging'
 import {state} from '../env/state'
 
 export async function setupToken(develocityAccessKey: string, develocityTokenExpiry: string): Promise<void> {
     if (develocityAccessKey) {
         try {
-            core.debug('Fetching short-lived token...')
+            log.debug('Fetching short-lived token...')
             const tokens = await getToken(develocityAccessKey, develocityTokenExpiry)
             if (tokens != null && !tokens.isEmpty()) {
-                core.debug(`Got token(s), setting the access key env vars`)
+                log.debug(`Got token(s), setting the access key env vars`)
                 const token = tokens.raw()
                 core.setSecret(token)
                 exportAccessKeyEnvVars(token)
@@ -19,7 +20,7 @@ export async function setupToken(develocityAccessKey: string, develocityTokenExp
             }
         } catch (e) {
             handleMissingAccessToken()
-            core.warning(`Failed to fetch short-lived token, reason: ${e}`)
+            log.warn(`Failed to fetch short-lived token, reason: ${e}`)
         }
     }
 }
@@ -31,14 +32,14 @@ function exportAccessKeyEnvVars(value: string): void {
 }
 
 function handleMissingAccessToken(): void {
-    core.warning(`Failed to fetch short-lived token for Develocity`)
+    log.warn(`Failed to fetch short-lived token for Develocity`)
 
     if (process.env[BuildScanConfig.GradleEnterpriseAccessKeyEnvVar]) {
         // We do not clear the GRADLE_ENTERPRISE_ACCESS_KEY env var in v3, to let the users upgrade to DV 2024.1
         recordDeprecation(`The ${BuildScanConfig.GradleEnterpriseAccessKeyEnvVar} env var is deprecated`)
     }
     if (process.env[BuildScanConfig.DevelocityAccessKeyEnvVar]) {
-        core.warning(`The ${BuildScanConfig.DevelocityAccessKeyEnvVar} env var should be mapped to a short-lived token`)
+        log.warn(`The ${BuildScanConfig.DevelocityAccessKeyEnvVar} env var should be mapped to a short-lived token`)
     }
 }
 
@@ -53,12 +54,12 @@ export async function getToken(accessKey: string, expiry: string): Promise<Devel
     const tokens = new Array<HostnameAccessKey>()
     for (const k of develocityAccessKey.keys) {
         try {
-            core.info(`Requesting short-lived Develocity access token for ${k.hostname}`)
+            log.info(`Requesting short-lived Develocity access token for ${k.hostname}`)
             const token = await shortLivedTokenClient.fetchToken(`https://${k.hostname}`, k, expiry)
             tokens.push(token)
         } catch (e) {
             // Ignore failure to obtain token
-            core.info(`Failed to obtain short-lived Develocity access token for ${k.hostname}: ${e}`)
+            log.info(`Failed to obtain short-lived Develocity access token for ${k.hostname}: ${e}`)
         }
     }
     if (tokens.length > 0) {
@@ -84,7 +85,7 @@ class ShortLivedTokenClient {
         while (attempts < this.maxRetries) {
             try {
                 const requestUrl = `${sanitizedServerUrl}api/auth/token${queryParams}`
-                core.debug(`Attempt ${attempts} to fetch short lived token at ${requestUrl}`)
+                log.debug(`Attempt ${attempts} to fetch short lived token at ${requestUrl}`)
                 const response = await this.httpc.post(requestUrl, '', headers)
                 if (response.message.statusCode === 200) {
                     const text = await response.readBody()

--- a/sources/src/develocity/short-lived-token.ts
+++ b/sources/src/develocity/short-lived-token.ts
@@ -2,6 +2,7 @@ import * as httpm from 'typed-rest-client/HttpClient'
 import * as core from '@actions/core'
 import {BuildScanConfig} from '../configuration'
 import {recordDeprecation} from '../deprecation-collector'
+import {state} from '../env/state'
 
 export async function setupToken(develocityAccessKey: string, develocityTokenExpiry: string): Promise<void> {
     if (develocityAccessKey) {
@@ -25,7 +26,7 @@ export async function setupToken(develocityAccessKey: string, develocityTokenExp
 
 function exportAccessKeyEnvVars(value: string): void {
     ;[BuildScanConfig.DevelocityAccessKeyEnvVar, BuildScanConfig.GradleEnterpriseAccessKeyEnvVar].forEach(key =>
-        core.exportVariable(key, value)
+        state.exportVariable(key, value)
     )
 }
 

--- a/sources/src/env/logging.ts
+++ b/sources/src/env/logging.ts
@@ -1,0 +1,55 @@
+import {state} from './state'
+
+/**
+ * Provides simple access to log levels.
+ */
+export enum LogLevel {
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR
+}
+
+/**
+ * Log writer function, called by [Logger] to write log messages.
+ */
+export type LoggerWriter = (level: LogLevel, message: string) => void
+
+/**
+ * Provides a thin wrapper around a log class that can be changed to different implementations.
+ */
+class Logger {
+    private writer: LoggerWriter
+
+    constructor() {
+        this.writer = (level: LogLevel, message: string) => {
+            // eslint-disable-next-line no-console
+            console.log(`[${LogLevel[level]}] ${message}`)
+        }
+    }
+
+    setWriter(writer: LoggerWriter): void {
+        this.writer = writer
+    }
+
+    debug(message: string): void {
+        this.writer(LogLevel.DEBUG, message)
+    }
+    cacheDebug(message: string): void {
+        if (state.isCacheDebuggingEnabled()) {
+            this.info(message)
+        } else {
+            this.debug(message)
+        }
+    }
+
+    info(message: string): void {
+        this.writer(LogLevel.INFO, message)
+    }
+
+    warn(message: string): void {
+        this.writer(LogLevel.WARN, message)
+    }
+}
+
+export const log = new Logger()

--- a/sources/src/env/state.ts
+++ b/sources/src/env/state.ts
@@ -77,6 +77,13 @@ class GradleEnvState implements GradleEnvStateImplementation {
         return this.impl.isDebug()
     }
 
+    isCacheDebuggingEnabled(): boolean {
+        if (state.isDebug()) {
+            return true
+        }
+        return process.env['GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED'] ? true : false
+    }
+
     get(key: string): string {
         return this.impl.get(key)
     }

--- a/sources/src/env/state.ts
+++ b/sources/src/env/state.ts
@@ -1,0 +1,134 @@
+/**
+ * Provides read/write access to saving state within the environment.
+ */
+export interface GradleEnvStateImplementation {
+    /**
+     * True if this build is being debugged.
+     */
+    isDebug(): boolean
+
+    /**
+     * Read a persistent value.
+     *
+     * @param key Property key
+     * @returns The value of the property or `''` if not found.
+     */
+    get(key: string): string
+
+    /**
+     * Write a persistent value.
+     *
+     * @param key Property key
+     * @param value Value to store
+     */
+    set(key: string, value: string): void
+
+    /**
+     * Read an input parameter from the triggered workflow.
+     * @param key Input key
+     * @param options optional. See [GradleEnvInputOptions].
+     * @returns The value of the input or `''` if not found.
+     */
+    getInput(key: string, options?: GradleEnvInputOptions): string
+
+    /**
+     * Gets the values of an multiline input.  Each value is also trimmed.
+     *
+     * @param     name     name of the input to get
+     * @param     options  optional. See [GradleEnvInputOptions].
+     * @returns   string[] Values stored, or empty array if not found.
+     */
+    getMultilineInput(name: string, options?: GradleEnvInputOptions): string[]
+
+    /**
+     * Sets env variable for this action and future actions in the job.
+     *
+     * @param name the name of the variable to set
+     * @param val the value of the variable.
+     */
+    exportVariable(name: string, val: string): void
+
+    /**
+     * Sets the action status to failed.
+     * When the action exits it will be with an exit code of 1
+     * @param message add error issue message
+     */
+    setFailed(message: string | Error): void
+}
+
+export interface GradleEnvInputOptions {
+    /**
+     * True if input is required.
+     */
+    readonly required?: boolean
+}
+
+/**
+ * Provides read/write access to saving state within the environment.
+ */
+class GradleEnvState implements GradleEnvStateImplementation {
+    private impl!: GradleEnvStateImplementation
+
+    setImpl(impl: GradleEnvStateImplementation): void {
+        this.impl = impl
+    }
+
+    isDebug(): boolean {
+        return this.impl.isDebug()
+    }
+
+    get(key: string): string {
+        return this.impl.get(key)
+    }
+
+    set(key: string, value: string): void {
+        this.impl.set(key, value)
+    }
+
+    getInput(key: string, options?: GradleEnvInputOptions): string {
+        return this.impl.getInput(key, options)
+    }
+
+    getMultilineInput(name: string, options?: GradleEnvInputOptions): string[] {
+        return this.impl.getMultilineInput(name, options)
+    }
+
+    getOptionalInput(paramName: string): string | undefined {
+        const paramValue = this.getInput(paramName)
+        if (paramValue.length > 0) {
+            return paramValue
+        }
+        return undefined
+    }
+
+    getBooleanInput(paramName: string, paramDefault = false): boolean {
+        const paramValue = this.getInput(paramName)
+        switch (paramValue.toLowerCase().trim()) {
+            case '':
+                return paramDefault
+            case 'false':
+                return false
+            case 'true':
+                return true
+        }
+        throw TypeError(`The value '${paramValue} is not valid for '${paramName}. Valid values are: [true, false]`)
+    }
+
+    getOptionalBooleanInput(paramName: string): boolean | undefined {
+        const paramValue = this.getInput(paramName)
+        if (paramValue === '') {
+            return undefined
+        }
+        return this.getBooleanInput(paramName)
+    }
+
+    exportVariable(name: string, val: string): void {
+        return this.impl.exportVariable(name, val)
+    }
+
+    setFailed(message: string | Error): void {
+        return this.impl.setFailed(message)
+    }
+}
+
+export const state = new GradleEnvState()

--- a/sources/src/errors.ts
+++ b/sources/src/errors.ts
@@ -1,6 +1,8 @@
 import * as core from '@actions/core'
 import {state} from './env/state'
 
+import {log} from './env/logging'
+
 export class JobFailure extends Error {
     constructor(error: unknown) {
         if (error instanceof Error) {
@@ -19,18 +21,18 @@ export function handleMainActionError(error: unknown): void {
         for (const err of error.errors) {
             core.error(`Error ${error.errors.indexOf(err)}: ${err.message}`)
             if (err.stack) {
-                core.info(err.stack)
+                log.info(err.stack)
             }
         }
     } else if (error instanceof JobFailure) {
         state.setFailed(String(error))
         if (error.stack) {
-            core.info(error.stack)
+            log.info(error.stack)
         }
     } else {
         state.setFailed(String(error))
         if (error instanceof Error && error.stack) {
-            core.info(error.stack)
+            log.info(error.stack)
         }
     }
 }
@@ -39,12 +41,12 @@ export function handlePostActionError(error: unknown): void {
     if (error instanceof JobFailure) {
         state.setFailed(String(error))
         if (error.stack) {
-            core.info(error.stack)
+            log.info(error.stack)
         }
     } else {
-        core.warning(`Unhandled error in Gradle post-action - job will continue: ${error}`)
+        log.warn(`Unhandled error in Gradle post-action - job will continue: ${error}`)
         if (error instanceof Error && error.stack) {
-            core.info(error.stack)
+            log.info(error.stack)
         }
     }
 }

--- a/sources/src/errors.ts
+++ b/sources/src/errors.ts
@@ -1,4 +1,5 @@
 import * as core from '@actions/core'
+import {state} from './env/state'
 
 export class JobFailure extends Error {
     constructor(error: unknown) {
@@ -14,7 +15,7 @@ export class JobFailure extends Error {
 
 export function handleMainActionError(error: unknown): void {
     if (error instanceof AggregateError) {
-        core.setFailed(`Multiple errors returned`)
+        state.setFailed(`Multiple errors returned`)
         for (const err of error.errors) {
             core.error(`Error ${error.errors.indexOf(err)}: ${err.message}`)
             if (err.stack) {
@@ -22,12 +23,12 @@ export function handleMainActionError(error: unknown): void {
             }
         }
     } else if (error instanceof JobFailure) {
-        core.setFailed(String(error))
+        state.setFailed(String(error))
         if (error.stack) {
             core.info(error.stack)
         }
     } else {
-        core.setFailed(String(error))
+        state.setFailed(String(error))
         if (error instanceof Error && error.stack) {
             core.info(error.stack)
         }
@@ -36,7 +37,7 @@ export function handleMainActionError(error: unknown): void {
 
 export function handlePostActionError(error: unknown): void {
     if (error instanceof JobFailure) {
-        core.setFailed(String(error))
+        state.setFailed(String(error))
         if (error.stack) {
             core.info(error.stack)
         }

--- a/sources/src/execution/gradle.ts
+++ b/sources/src/execution/gradle.ts
@@ -1,10 +1,10 @@
-import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 
 import which from 'which'
 import * as semver from 'semver'
 import * as provisioner from './provision'
 import * as gradlew from './gradlew'
+import {state} from '../env/state'
 
 export async function provisionAndMaybeExecute(
     gradleVersion: string,
@@ -30,7 +30,7 @@ async function executeGradleBuild(executable: string | undefined, root: string, 
     })
 
     if (status !== 0) {
-        core.setFailed(`Gradle build failed: see console output for details`)
+        state.setFailed(`Gradle build failed: see console output for details`)
     }
 }
 

--- a/sources/src/execution/gradlew.ts
+++ b/sources/src/execution/gradlew.ts
@@ -1,6 +1,6 @@
-import * as core from '@actions/core'
 import * as path from 'path'
 import fs from 'fs'
+import {log} from '../env/logging'
 
 const IS_WINDOWS = process.platform === 'win32'
 
@@ -38,7 +38,7 @@ function verifyIsExecutableScript(toExecute: string): void {
     try {
         fs.accessSync(toExecute, fs.constants.X_OK)
     } catch (err) {
-        core.warning(
+        log.warn(
             `Gradle wrapper script '${toExecute}' is not executable. Action will set executable permission and continue.`
         )
         fs.chmodSync(toExecute, '755')

--- a/sources/src/execution/provision.ts
+++ b/sources/src/execution/provision.ts
@@ -10,6 +10,7 @@ import {findGradleVersionOnPath, versionIsAtLeast} from './gradle'
 import * as gradlew from './gradlew'
 import {handleCacheFailure} from '../caching/cache-utils'
 import {CacheConfig} from '../configuration'
+import {log} from '../env/logging'
 
 const gradleVersionsBaseUrl = 'https://services.gradle.org/versions'
 
@@ -51,7 +52,7 @@ async function resolveGradleVersion(version: string): Promise<GradleVersionInfo>
         case 'current':
             return gradleCurrent()
         case 'rc':
-            core.warning(`Specifying gradle-version 'rc' has been deprecated. Use 'release-candidate' instead.`)
+            log.warn(`Specifying gradle-version 'rc' has been deprecated. Use 'release-candidate' instead.`)
             return gradleReleaseCandidate()
         case 'release-candidate':
             return gradleReleaseCandidate()
@@ -73,7 +74,7 @@ async function gradleReleaseCandidate(): Promise<GradleVersionInfo> {
     if (versionInfo && versionInfo.version && versionInfo.downloadUrl) {
         return versionInfo
     }
-    core.info('No current release-candidate found, will fallback to current')
+    log.info('No current release-candidate found, will fallback to current')
     return gradleCurrent()
 }
 
@@ -108,7 +109,7 @@ async function installGradleVersion(versionInfo: GradleVersionInfo): Promise<str
     return core.group(`Provision Gradle ${versionInfo.version}`, async () => {
         const gradleOnPath = await findGradleVersionOnPath()
         if (gradleOnPath?.version === versionInfo.version) {
-            core.info(`Gradle version ${versionInfo.version} is already available on PATH. Not installing.`)
+            log.info(`Gradle version ${versionInfo.version} is already available on PATH. Not installing.`)
             return gradleOnPath.executable
         }
 
@@ -120,7 +121,7 @@ async function installGradleVersionAtLeast(versionInfo: GradleVersionInfo): Prom
     return core.group(`Provision Gradle >= ${versionInfo.version}`, async () => {
         const gradleOnPath = await findGradleVersionOnPath()
         if (gradleOnPath && versionIsAtLeast(gradleOnPath.version, versionInfo.version)) {
-            core.info(
+            log.info(
                 `Gradle version ${gradleOnPath.version} is available on PATH and >= ${versionInfo.version}. Not installing.`
             )
             return gradleOnPath.executable
@@ -134,17 +135,17 @@ async function locateGradleAndDownloadIfRequired(versionInfo: GradleVersionInfo)
     const installsDir = path.join(getProvisionDir(), 'installs')
     const installDir = path.join(installsDir, `gradle-${versionInfo.version}`)
     if (fs.existsSync(installDir)) {
-        core.info(`Gradle installation already exists at ${installDir}`)
+        log.info(`Gradle installation already exists at ${installDir}`)
         return executableFrom(installDir)
     }
 
     const downloadPath = await downloadAndCacheGradleDistribution(versionInfo)
     await toolCache.extractZip(downloadPath, installsDir)
-    core.info(`Extracted Gradle ${versionInfo.version} to ${installDir}`)
+    log.info(`Extracted Gradle ${versionInfo.version} to ${installDir}`)
 
     const executable = executableFrom(installDir)
     fs.chmodSync(executable, '755')
-    core.info(`Provisioned Gradle executable ${executable}`)
+    log.info(`Provisioned Gradle executable ${executable}`)
 
     return executable
 }
@@ -163,14 +164,14 @@ async function downloadAndCacheGradleDistribution(versionInfo: GradleVersionInfo
     try {
         const restoreKey = await cache.restoreCache([downloadPath], cacheKey)
         if (restoreKey) {
-            core.info(`Restored Gradle distribution ${cacheKey} from cache to ${downloadPath}`)
+            log.info(`Restored Gradle distribution ${cacheKey} from cache to ${downloadPath}`)
             return downloadPath
         }
     } catch (error) {
         handleCacheFailure(error, `Restore Gradle distribution ${versionInfo.version} failed`)
     }
 
-    core.info(`Gradle distribution ${versionInfo.version} not found in cache. Will download.`)
+    log.info(`Gradle distribution ${versionInfo.version} not found in cache. Will download.`)
     await downloadGradleDistribution(versionInfo, downloadPath)
 
     if (!cacheConfig.isCacheReadOnly()) {
@@ -190,7 +191,7 @@ function getProvisionDir(): string {
 
 async function downloadGradleDistribution(versionInfo: GradleVersionInfo, downloadPath: string): Promise<void> {
     await toolCache.downloadTool(versionInfo.downloadUrl, downloadPath)
-    core.info(`Downloaded ${versionInfo.downloadUrl} to ${downloadPath} (size ${fs.statSync(downloadPath).size})`)
+    log.info(`Downloaded ${versionInfo.downloadUrl} to ${downloadPath} (size ${fs.statSync(downloadPath).size})`)
 }
 
 function executableFrom(installDir: string): string {

--- a/sources/src/job-summary.ts
+++ b/sources/src/job-summary.ts
@@ -5,6 +5,7 @@ import {RequestError} from '@octokit/request-error'
 import {BuildResults, BuildResult} from './build-results'
 import {SummaryConfig, getActionId, getGithubToken} from './configuration'
 import {Deprecation, getDeprecations, getErrors} from './deprecation-collector'
+import {log} from './env/logging'
 
 export async function generateJobSummary(
     buildResults: BuildResults,
@@ -22,17 +23,17 @@ export async function generateJobSummary(
 
     const hasFailure = buildResults.anyFailed()
     if (config.shouldGenerateJobSummary(hasFailure)) {
-        core.info('Generating Job Summary')
+        log.info('Generating Job Summary')
 
         core.summary.addRaw(summaryTable)
         core.summary.addRaw(cachingReport)
         await core.summary.write()
     } else {
-        core.info('============================')
-        core.info(summaryTable)
-        core.info('============================')
-        core.info(cachingReport)
-        core.info('============================')
+        log.info('============================')
+        log.info(summaryTable)
+        log.info('============================')
+        log.info(cachingReport)
+        log.info('============================')
     }
 
     if (config.shouldAddPRComment(hasFailure)) {
@@ -43,12 +44,12 @@ export async function generateJobSummary(
 async function addPRComment(jobSummary: string): Promise<void> {
     const context = github.context
     if (context.payload.pull_request == null) {
-        core.info('No pull_request trigger detected: not adding PR comment')
+        log.info('No pull_request trigger detected: not adding PR comment')
         return
     }
 
     const pull_request_number = context.payload.pull_request.number
-    core.info(`Adding Job Summary as comment to PR #${pull_request_number}.`)
+    log.info(`Adding Job Summary as comment to PR #${pull_request_number}.`)
 
     const prComment = `<h3>Job Summary for Gradle</h3>
 <a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}" target="_blank">
@@ -67,7 +68,7 @@ ${jobSummary}`
         })
     } catch (error) {
         if (error instanceof RequestError) {
-            core.warning(buildWarningMessage(error))
+            log.warn(buildWarningMessage(error))
         } else {
             throw error
         }

--- a/sources/src/setup-gradle.ts
+++ b/sources/src/setup-gradle.ts
@@ -1,4 +1,3 @@
-import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import * as fs from 'fs'
 import * as path from 'path'
@@ -18,6 +17,7 @@ import {
     getWorkspaceDirectory
 } from './configuration'
 import * as wrapperValidator from './wrapper-validation/wrapper-validator'
+import {log} from './env/logging'
 import {state} from './env/state'
 
 const GRADLE_SETUP_VAR = 'GRADLE_BUILD_ACTION_SETUP_COMPLETED'
@@ -35,7 +35,7 @@ export async function setup(
 
     // Bypass setup on all but first action step in workflow.
     if (process.env[GRADLE_SETUP_VAR]) {
-        core.info('Gradle setup only performed on first gradle/actions step in workflow.')
+        log.info('Gradle setup only performed on first gradle/actions step in workflow.')
         return false
     }
     // Record setup complete: visible to all subsequent actions and prevents duplicate setup
@@ -61,10 +61,10 @@ export async function setup(
 
 export async function complete(cacheConfig: CacheConfig, summaryConfig: SummaryConfig): Promise<boolean> {
     if (!state.get(GRADLE_SETUP_VAR)) {
-        core.info('Gradle setup post-action only performed for first gradle/actions step in workflow.')
+        log.info('Gradle setup post-action only performed for first gradle/actions step in workflow.')
         return false
     }
-    core.info('In post-action step')
+    log.info('In post-action step')
 
     const buildResults = loadBuildResults()
 
@@ -80,7 +80,7 @@ export async function complete(cacheConfig: CacheConfig, summaryConfig: SummaryC
 
     markBuildResultsProcessed()
 
-    core.info('Completed post-action step')
+    log.info('Completed post-action step')
 
     return true
 }
@@ -95,7 +95,7 @@ async function determineGradleUserHome(): Promise<string> {
     const defaultGradleUserHome = path.resolve(await determineUserHome(), '.gradle')
     // Use the default Gradle User Home if it already exists
     if (fs.existsSync(defaultGradleUserHome)) {
-        core.info(`Gradle User Home already exists at ${defaultGradleUserHome}`)
+        log.info(`Gradle User Home already exists at ${defaultGradleUserHome}`)
         state.exportVariable('GRADLE_USER_HOME', defaultGradleUserHome)
         return defaultGradleUserHome
     }
@@ -103,7 +103,7 @@ async function determineGradleUserHome(): Promise<string> {
     // Switch Gradle User Home to faster 'D:' drive if possible
     if (os.platform() === 'win32' && defaultGradleUserHome.startsWith('C:\\') && fs.existsSync('D:\\a\\')) {
         const fasterGradleUserHome = 'D:\\a\\.gradle'
-        core.info(`Setting GRADLE_USER_HOME to ${fasterGradleUserHome} to leverage (potentially) faster drive.`)
+        log.info(`Setting GRADLE_USER_HOME to ${fasterGradleUserHome} to leverage (potentially) faster drive.`)
         state.exportVariable('GRADLE_USER_HOME', fasterGradleUserHome)
         return fasterGradleUserHome
     }
@@ -121,10 +121,10 @@ async function determineUserHome(): Promise<string> {
     const regex = /user\.home = (\S*)/i
     const found = output.stderr.match(regex)
     if (found == null || found.length <= 1) {
-        core.info('Could not determine user.home from java -version output. Using os.homedir().')
+        log.info('Could not determine user.home from java -version output. Using os.homedir().')
         return os.homedir()
     }
     const userHome = found[1]
-    core.debug(`Determined user.home from java -version output: '${userHome}'`)
+    log.debug(`Determined user.home from java -version output: '${userHome}'`)
     return userHome
 }

--- a/sources/src/setup-gradle.ts
+++ b/sources/src/setup-gradle.ts
@@ -18,6 +18,7 @@ import {
     getWorkspaceDirectory
 } from './configuration'
 import * as wrapperValidator from './wrapper-validation/wrapper-validator'
+import {state} from './env/state'
 
 const GRADLE_SETUP_VAR = 'GRADLE_BUILD_ACTION_SETUP_COMPLETED'
 const USER_HOME = 'USER_HOME'
@@ -38,18 +39,18 @@ export async function setup(
         return false
     }
     // Record setup complete: visible to all subsequent actions and prevents duplicate setup
-    core.exportVariable(GRADLE_SETUP_VAR, true)
+    state.exportVariable(GRADLE_SETUP_VAR, true.toString())
     // Record setup complete: visible in post-action, to control action completion
-    core.saveState(GRADLE_SETUP_VAR, true)
+    state.set(GRADLE_SETUP_VAR, true.toString())
 
     // Save the User Home and Gradle User Home for use in the post-action step.
-    core.saveState(USER_HOME, userHome)
-    core.saveState(GRADLE_USER_HOME, gradleUserHome)
+    state.set(USER_HOME, userHome)
+    state.set(GRADLE_USER_HOME, gradleUserHome)
 
     const cacheListener = new CacheListener()
     await caches.restore(userHome, gradleUserHome, cacheListener, cacheConfig)
 
-    core.saveState(CACHE_LISTENER, cacheListener.stringify())
+    state.set(CACHE_LISTENER, cacheListener.stringify())
 
     await wrapperValidator.validateWrappers(wrapperValidationConfig, getWorkspaceDirectory(), gradleUserHome)
 
@@ -59,7 +60,7 @@ export async function setup(
 }
 
 export async function complete(cacheConfig: CacheConfig, summaryConfig: SummaryConfig): Promise<boolean> {
-    if (!core.getState(GRADLE_SETUP_VAR)) {
+    if (!state.get(GRADLE_SETUP_VAR)) {
         core.info('Gradle setup post-action only performed for first gradle/actions step in workflow.')
         return false
     }
@@ -67,9 +68,9 @@ export async function complete(cacheConfig: CacheConfig, summaryConfig: SummaryC
 
     const buildResults = loadBuildResults()
 
-    const userHome = core.getState(USER_HOME)
-    const gradleUserHome = core.getState(GRADLE_USER_HOME)
-    const cacheListener: CacheListener = CacheListener.rehydrate(core.getState(CACHE_LISTENER))
+    const userHome = state.get(USER_HOME)
+    const gradleUserHome = state.get(GRADLE_USER_HOME)
+    const cacheListener: CacheListener = CacheListener.rehydrate(state.get(CACHE_LISTENER))
 
     const daemonController = new DaemonController(buildResults)
     await caches.save(userHome, gradleUserHome, cacheListener, daemonController, buildResults, cacheConfig)
@@ -95,7 +96,7 @@ async function determineGradleUserHome(): Promise<string> {
     // Use the default Gradle User Home if it already exists
     if (fs.existsSync(defaultGradleUserHome)) {
         core.info(`Gradle User Home already exists at ${defaultGradleUserHome}`)
-        core.exportVariable('GRADLE_USER_HOME', defaultGradleUserHome)
+        state.exportVariable('GRADLE_USER_HOME', defaultGradleUserHome)
         return defaultGradleUserHome
     }
 
@@ -103,11 +104,11 @@ async function determineGradleUserHome(): Promise<string> {
     if (os.platform() === 'win32' && defaultGradleUserHome.startsWith('C:\\') && fs.existsSync('D:\\a\\')) {
         const fasterGradleUserHome = 'D:\\a\\.gradle'
         core.info(`Setting GRADLE_USER_HOME to ${fasterGradleUserHome} to leverage (potentially) faster drive.`)
-        core.exportVariable('GRADLE_USER_HOME', fasterGradleUserHome)
+        state.exportVariable('GRADLE_USER_HOME', fasterGradleUserHome)
         return fasterGradleUserHome
     }
 
-    core.exportVariable('GRADLE_USER_HOME', defaultGradleUserHome)
+    state.exportVariable('GRADLE_USER_HOME', defaultGradleUserHome)
     return defaultGradleUserHome
 }
 

--- a/sources/src/wrapper-validation/checksums.ts
+++ b/sources/src/wrapper-validation/checksums.ts
@@ -1,6 +1,6 @@
 import * as httpm from 'typed-rest-client/HttpClient'
 import * as cheerio from 'cheerio'
-import * as core from '@actions/core'
+import {log} from '../env/logging'
 
 import fileWrapperChecksums from './wrapper-checksums.json'
 
@@ -104,6 +104,6 @@ async function fetchAndStoreChecksums(
                 wrapperChecksums.add(version, checksum)
             })
         )
-        core.info(`Fetched ${i + batch.length} of ${checksumUrls.length} checksums`)
+        log.info(`Fetched ${i + batch.length} of ${checksumUrls.length} checksums`)
     }
 }

--- a/sources/src/wrapper-validation/wrapper-validator.ts
+++ b/sources/src/wrapper-validation/wrapper-validator.ts
@@ -4,6 +4,7 @@ import {WrapperValidationConfig} from '../configuration'
 import {ChecksumCache} from './cache'
 import {findInvalidWrapperJars} from './validate'
 import {JobFailure} from '../errors'
+import {log} from '../env/logging'
 
 export async function validateWrappers(
     config: WrapperValidationConfig,
@@ -26,11 +27,11 @@ export async function validateWrappers(
     )
     if (result.isValid()) {
         await core.group('All Gradle Wrapper jars are valid', async () => {
-            core.debug(`Loaded previously validated checksums from cache: ${previouslyValidatedChecksums.join(', ')}`)
-            core.info(result.toDisplayString())
+            log.debug(`Loaded previously validated checksums from cache: ${previouslyValidatedChecksums.join(', ')}`)
+            log.info(result.toDisplayString())
         })
     } else {
-        core.info(result.toDisplayString())
+        log.info(result.toDisplayString())
         throw new JobFailure(
             `At least one Gradle Wrapper Jar failed validation!\n  See https://github.com/gradle/actions/blob/main/docs/wrapper-validation.md#validation-failures\n${result.toDisplayString()}`
         )

--- a/sources/test/jest/cache-cleanup.test.ts
+++ b/sources/test/jest/cache-cleanup.test.ts
@@ -5,6 +5,9 @@ import fs from 'fs'
 import path from 'path'
 import {CacheCleaner} from '../../src/caching/cache-cleaner'
 
+import { configureTestEnv } from './test-env'
+configureTestEnv()
+
 jest.setTimeout(120000)
 
 test('will cleanup unused dependency jars and build-cache entries', async () => {

--- a/sources/test/jest/cache-debug.test.ts
+++ b/sources/test/jest/cache-debug.test.ts
@@ -3,6 +3,9 @@ import * as fs from 'fs'
 import {GradleUserHomeCache} from "../../src/caching/gradle-user-home-cache"
 import {CacheConfig} from "../../src/configuration"
 
+import { configureTestEnv } from './test-env'
+configureTestEnv()
+
 const testTmp = 'test/jest/tmp'
 fs.rmSync(testTmp, {recursive: true, force: true})
 

--- a/sources/test/jest/cache-reporting.test.ts
+++ b/sources/test/jest/cache-reporting.test.ts
@@ -1,5 +1,7 @@
-import exp from 'constants'
 import {CacheEntryListener, CacheListener} from '../../src/caching/cache-reporting'
+
+import { configureTestEnv } from './test-env'
+configureTestEnv()
 
 describe('caching report', () => {
     describe('reports not fully restored', () => {

--- a/sources/test/jest/cache-utils.test.ts
+++ b/sources/test/jest/cache-utils.test.ts
@@ -1,5 +1,8 @@
 import * as cacheUtils from '../../src/caching/cache-utils'
 
+import { configureTestEnv } from './test-env'
+configureTestEnv()
+
 describe('cacheUtils-utils', () => {
     describe('can hash', () => {
         it('a string', async () => {

--- a/sources/test/jest/configuration.test.ts
+++ b/sources/test/jest/configuration.test.ts
@@ -1,5 +1,8 @@
 import * as inputParams from '../../src/configuration'
 
+import { configureTestEnv } from './test-env'
+configureTestEnv()
+
 describe('input params', () => {
     describe('parses numeric input', () => {
         it('uses default value', () => {

--- a/sources/test/jest/dependency-graph.test.ts
+++ b/sources/test/jest/dependency-graph.test.ts
@@ -1,5 +1,8 @@
 import { DependencyGraphConfig } from "../../src/configuration" 
 
+import { configureTestEnv } from './test-env'
+configureTestEnv()
+
 describe('dependency-graph', () => {
     describe('constructs job correlator', () => {
         it('removes commas from workflow name', () => {

--- a/sources/test/jest/gradle-version.test.ts
+++ b/sources/test/jest/gradle-version.test.ts
@@ -1,6 +1,9 @@
 import { describe } from 'node:test'
 import { versionIsAtLeast, parseGradleVersionFromOutput } from '../../src/execution/gradle'
 
+import { configureTestEnv } from './test-env'
+configureTestEnv()
+
 describe('gradle', () => {
     describe('can compare version with', () => {
         it('same version', async () => {

--- a/sources/test/jest/job-summary.test.ts
+++ b/sources/test/jest/job-summary.test.ts
@@ -2,6 +2,9 @@ import { BuildResult } from '../../src/build-results'
 import { renderSummaryTable } from '../../src/job-summary'
 import dedent from 'dedent'
 
+import { configureTestEnv } from './test-env'
+configureTestEnv()
+
 
 const successfulHelpBuild: BuildResult = {
     rootProjectName: 'root',

--- a/sources/test/jest/predefined-toolchains.test.ts
+++ b/sources/test/jest/predefined-toolchains.test.ts
@@ -1,5 +1,8 @@
 import {getPredefinedToolchains, mergeToolchainContent} from "../../src/caching/gradle-user-home-utils";
 
+import { configureTestEnv } from './test-env'
+configureTestEnv()
+
 describe('predefined-toolchains', () => {
     const OLD_ENV = process.env
     afterAll(() => {

--- a/sources/test/jest/short-lived-token.test.ts
+++ b/sources/test/jest/short-lived-token.test.ts
@@ -1,6 +1,9 @@
 import {DevelocityAccessCredentials, getToken} from "../../src/develocity/short-lived-token";
 import nock from "nock";
 
+import { configureTestEnv } from './test-env'
+configureTestEnv()
+
 describe('short lived tokens', () => {
     it('parse valid access key should return an object', async () => {
         let develocityAccessCredentials = DevelocityAccessCredentials.parse('some-host.local=key1;host2=key2');

--- a/sources/test/jest/test-env.ts
+++ b/sources/test/jest/test-env.ts
@@ -1,0 +1,54 @@
+import { state, GradleEnvStateImplementation } from '../../src/env/state'
+
+class TestStateImplementation implements GradleEnvStateImplementation {
+    readonly state: Record<string, string> = {}
+
+    readonly inputs: Record<string, string> = {}
+
+    readonly env: Record<string, string> = {}
+
+    _isDebug = false
+
+    isDebug(): boolean {
+        return this._isDebug
+    }
+    
+    get(key: string): string {
+        return this.state[key] ?? ''
+    }
+
+    set(key: string, value: string): void {
+        this.state[key] = value
+    }
+
+    getInput(key: string): string {
+        return this.inputs[key] ?? ''
+    }
+
+    setInput(key: string, value: string) {
+        this.inputs[key] = value
+    }
+
+    getMultilineInput(name: string): string[] {
+        const input = this.inputs[name]
+        return input?.split('\n') ?? []
+    }
+
+    exportVariable(name: string, value: string): void {
+        process.env[name] = value
+    }
+
+    setFailed(message: string | Error): void {
+        throw new Error(message.toString())
+    }
+}
+
+const testState = new TestStateImplementation()
+
+function setupState(): void {
+    state.setImpl(testState)
+}
+
+export const configureTestEnv = (): void => {
+    setupState()
+}

--- a/sources/test/jest/wrapper-validation/checksums.test.ts
+++ b/sources/test/jest/wrapper-validation/checksums.test.ts
@@ -2,6 +2,9 @@ import * as checksums from '../../../src/wrapper-validation/checksums'
 import nock from 'nock'
 import {afterEach, describe, expect, test, jest} from '@jest/globals'
 
+import { configureTestEnv } from '../test-env'
+configureTestEnv()
+
 jest.setTimeout(60000)
 
 const CHECKSUM_8_1 = 'ed2c26eba7cfb93cc2b7785d05e534f07b5b48b5e7fc941921cd098628abca58'

--- a/sources/test/jest/wrapper-validation/find.test.ts
+++ b/sources/test/jest/wrapper-validation/find.test.ts
@@ -2,6 +2,9 @@ import * as path from 'path'
 import * as find from '../../../src/wrapper-validation/find'
 import {expect, test} from '@jest/globals'
 
+import { configureTestEnv } from '../test-env'
+configureTestEnv()
+
 test('finds test data wrapper jars', async () => {
   const repoRoot = path.resolve('./test/jest/wrapper-validation')
   const wrapperJars = await find.findWrapperJars(repoRoot)

--- a/sources/test/jest/wrapper-validation/hash.test.ts
+++ b/sources/test/jest/wrapper-validation/hash.test.ts
@@ -2,6 +2,9 @@ import * as path from 'path'
 import * as hash from '../../../src/wrapper-validation/hash'
 import {expect, test} from '@jest/globals'
 
+import { configureTestEnv } from '../test-env'
+configureTestEnv()
+
 test('can sha256 files', async () => {
   const sha = await hash.sha256File(
     path.resolve('test/jest/wrapper-validation/data/invalid/gradle-wrapper.jar')

--- a/sources/test/jest/wrapper-validation/validate.test.ts
+++ b/sources/test/jest/wrapper-validation/validate.test.ts
@@ -4,7 +4,9 @@ import * as validate from '../../../src/wrapper-validation/validate'
 import {expect, test, jest} from '@jest/globals'
 import { WrapperChecksums, KNOWN_CHECKSUMS } from '../../../src/wrapper-validation/checksums'
 import { ChecksumCache } from '../../../src/wrapper-validation/cache'
-import exp from 'constants'
+
+import { configureTestEnv } from '../test-env'
+configureTestEnv()
 
 jest.setTimeout(30000)
 


### PR DESCRIPTION
There is no functional changes present, logging is moved behind small wrapper class to provide a simple abstraction to be replaced. 

Currently, we implement this in terms of `Github Actions` -- for obvious reasons. In the future, this enables implementation in other, non-Github CI environments. 

Part of gradle/actions#502.