### PR TITLE
MultiCI: Abstract Github Action exec calls to wrapper

### DIFF
--- a/sources/src/actions/github-actions-env.ts
+++ b/sources/src/actions/github-actions-env.ts
@@ -1,5 +1,7 @@
 import * as core from '@actions/core'
-import {log, LogLevel, state} from '../env'
+import * as ghExec from '@actions/exec'
+
+import {exec, CIExecOptions, log, LogLevel, state} from '../env'
 
 function setupState(): void {
     state.setImpl({
@@ -36,7 +38,30 @@ function setupLogger(): void {
     })
 }
 
+function setupExec(): void {
+    exec.setImpl({
+        group: core.group,
+
+        run: async (command: string, args?: string[], options?: CIExecOptions): Promise<void> => {
+            await ghExec.exec(command, args, options)
+        },
+
+        exec: async (commandLine: string, args?: string[], options?: CIExecOptions): Promise<number> => {
+            return await ghExec.exec(commandLine, args, options)
+        },
+
+        getExecOutput: async (
+            command: string,
+            args?: string[],
+            options?: CIExecOptions
+        ): Promise<{stdout: string; stderr: string}> => {
+            return await ghExec.getExecOutput(command, args, options)
+        }
+    })
+}
+
 export const configureGithubEnv = (): void => {
     setupState()
     setupLogger()
+    setupExec()
 }

--- a/sources/src/caching/cache-cleaner.ts
+++ b/sources/src/caching/cache-cleaner.ts
@@ -1,10 +1,7 @@
-import * as core from '@actions/core'
-import * as exec from '@actions/exec'
-
 import fs from 'fs'
 import path from 'path'
 import * as provisioner from '../execution/provision'
-import {log, state} from '../env'
+import {exec, log, state} from '../env'
 
 export class CacheCleaner {
     private readonly gradleUserHome: string
@@ -59,7 +56,7 @@ export class CacheCleaner {
         // TODO: This is ineffective: we should be using the newest version of Gradle that ran a build, or a newer version if it's available on PATH.
         const executable = await provisioner.provisionGradleAtLeast('8.12')
 
-        await core.group('Executing Gradle to clean up caches', async () => {
+        await exec.group('Executing Gradle to clean up caches', async () => {
             log.info(`Cleaning up caches last used before ${cleanTimestamp}`)
             await this.executeCleanupBuild(executable, cleanupProjectDir)
         })

--- a/sources/src/caching/cache-utils.ts
+++ b/sources/src/caching/cache-utils.ts
@@ -1,11 +1,10 @@
 import * as cache from '@actions/cache'
-import * as exec from '@actions/exec'
 
 import * as crypto from 'crypto'
 import * as path from 'path'
 import * as fs from 'fs'
 
-import {log} from '../env'
+import {exec, log} from '../env'
 import {CacheEntryListener} from './cache-reporting'
 
 const SEGMENT_DOWNLOAD_TIMEOUT_VAR = 'SEGMENT_DOWNLOAD_TIMEOUT_MINS'

--- a/sources/src/caching/caches.ts
+++ b/sources/src/caching/caches.ts
@@ -1,4 +1,3 @@
-import * as core from '@actions/core'
 import {
     CacheListener,
     EXISTING_GRADLE_HOME,
@@ -10,7 +9,7 @@ import {CacheCleaner} from './cache-cleaner'
 import {DaemonController} from '../daemon-controller'
 import {CacheConfig} from '../configuration'
 import {BuildResults} from '../build-results'
-import {log, state} from '../env'
+import {exec, log, state} from '../env'
 
 const CACHE_RESTORED_VAR = 'GRADLE_BUILD_ACTION_CACHE_RESTORED'
 
@@ -64,7 +63,7 @@ export async function restore(
         return
     }
 
-    await core.group('Restore Gradle state from cache', async () => {
+    await exec.group('Restore Gradle state from cache', async () => {
         await gradleStateCache.restore(cacheListener)
     })
 }
@@ -93,7 +92,7 @@ export async function save(
         return
     }
 
-    await core.group('Stopping Gradle daemons', async () => {
+    await exec.group('Stopping Gradle daemons', async () => {
         await daemonController.stopAllDaemons()
     })
 
@@ -110,7 +109,7 @@ export async function save(
         }
     }
 
-    await core.group('Caching Gradle state', async () => {
+    await exec.group('Caching Gradle state', async () => {
         return new GradleUserHomeCache(userHome, gradleUserHome, cacheConfig).save(cacheListener)
     })
 }

--- a/sources/src/caching/gradle-user-home-cache.ts
+++ b/sources/src/caching/gradle-user-home-cache.ts
@@ -1,4 +1,3 @@
-import * as exec from '@actions/exec'
 import * as glob from '@actions/glob'
 
 import path from 'path'
@@ -9,7 +8,7 @@ import {saveCache, restoreCache, tryDelete} from './cache-utils'
 import {CacheConfig, ACTION_METADATA_DIR} from '../configuration'
 import {GradleHomeEntryExtractor, ConfigurationCacheEntryExtractor} from './gradle-home-extry-extractor'
 import {getPredefinedToolchains, mergeToolchainContent, readResourceFileAsString} from './gradle-user-home-utils'
-import {log, state} from '../env'
+import {exec, log, state} from '../env'
 
 const RESTORED_CACHE_KEY_KEY = 'restored-cache-key'
 

--- a/sources/src/daemon-controller.ts
+++ b/sources/src/daemon-controller.ts
@@ -1,8 +1,7 @@
-import * as exec from '@actions/exec'
 import * as fs from 'fs'
 import * as path from 'path'
 import {BuildResults} from './build-results'
-import {log} from './env'
+import {exec, log} from './env'
 
 export class DaemonController {
     private readonly gradleHomes

--- a/sources/src/env/execution.ts
+++ b/sources/src/env/execution.ts
@@ -1,0 +1,83 @@
+/**
+ * Provides a wrapper for execution of system commands in a job.
+ */
+export interface CIExecImplementation {
+    /**
+     * Wrap an asynchronous function call in a "group" of execution in a CI pipeline.
+     * @param name Name of the group.
+     * @param fn
+     */
+    group<R>(name: string, fn: () => Promise<R>): Promise<R>
+
+    /**
+     * Executes
+     * @param command
+     * @param args
+     */
+    run(command: string, args?: string[], options?: CIExecOptions): Promise<void>
+
+    /**
+     * Executes command and returns the output.
+     * @param command
+     * @param args
+     * @param options
+     */
+    getExecOutput(command: string, args?: string[], options?: CIExecOptions): Promise<{stdout: string; stderr: string}>
+
+    /**
+     * Exec a command.
+     * Output will be streamed to the live console.
+     * Returns promise with return code
+     *
+     * @param     commandLine        command to execute (can include additional args). Must be correctly escaped.
+     * @param     args               optional arguments for tool. Escaping is handled by the lib.
+     * @param     options            optional exec options.  See ExecOptions
+     * @returns   Promise<number>    exit code
+     */
+    exec(command: string, args?: string[], options?: CIExecOptions): Promise<number>
+}
+
+/**
+ * Interface for exec options
+ */
+export interface CIExecOptions {
+    /** optional working directory.  defaults to current */
+    cwd?: string
+
+    silent?: boolean
+
+    ignoreReturnCode?: boolean
+
+    /** optional envvar dictionary.  defaults to current process's env */
+    env?: {
+        [key: string]: string
+    }
+}
+
+export class CIExec implements CIExecImplementation {
+    private impl!: CIExecImplementation
+
+    setImpl(impl: CIExecImplementation): void {
+        this.impl = impl
+    }
+
+    async group<R>(name: string, fn: () => Promise<R>): Promise<R> {
+        return await this.impl.group(name, fn)
+    }
+
+    async run(command: string, args?: string[], options?: CIExecOptions): Promise<void> {
+        await this.impl.run(command, args, options)
+    }
+
+    async exec(command: string, args?: string[], options?: CIExecOptions): Promise<number> {
+        return await this.impl.exec(command, args, options)
+    }
+
+    async getExecOutput(
+        command: string,
+        args?: string[],
+        options?: CIExecOptions
+    ): Promise<{stdout: string; stderr: string}> {
+        return await this.impl.getExecOutput(command, args, options)
+    }
+}

--- a/sources/src/env/index.ts
+++ b/sources/src/env/index.ts
@@ -1,3 +1,4 @@
+import {CIExec} from './execution'
 import {Logger} from './logging'
 import {CIState} from './state'
 
@@ -6,3 +7,6 @@ export const state = new CIState()
 
 export {LogLevel} from './logging'
 export const log = new Logger()
+
+export const exec = new CIExec()
+export {CIExecImplementation, CIExecOptions} from './execution'

--- a/sources/src/execution/gradle.ts
+++ b/sources/src/execution/gradle.ts
@@ -1,10 +1,9 @@
-import * as exec from '@actions/exec'
-
 import which from 'which'
 import * as semver from 'semver'
+
 import * as provisioner from './provision'
 import * as gradlew from './gradlew'
-import {state} from '../env'
+import {exec, state} from '../env'
 
 export async function provisionAndMaybeExecute(
     gradleVersion: string,

--- a/sources/src/execution/provision.ts
+++ b/sources/src/execution/provision.ts
@@ -10,7 +10,7 @@ import {findGradleVersionOnPath, versionIsAtLeast} from './gradle'
 import * as gradlew from './gradlew'
 import {handleCacheFailure} from '../caching/cache-utils'
 import {CacheConfig} from '../configuration'
-import {log} from '../env'
+import {exec, log} from '../env'
 
 const gradleVersionsBaseUrl = 'https://services.gradle.org/versions'
 
@@ -106,7 +106,7 @@ async function findGradleVersionDeclaration(version: string): Promise<GradleVers
 }
 
 async function installGradleVersion(versionInfo: GradleVersionInfo): Promise<string> {
-    return core.group(`Provision Gradle ${versionInfo.version}`, async () => {
+    return exec.group(`Provision Gradle ${versionInfo.version}`, async () => {
         const gradleOnPath = await findGradleVersionOnPath()
         if (gradleOnPath?.version === versionInfo.version) {
             log.info(`Gradle version ${versionInfo.version} is already available on PATH. Not installing.`)
@@ -118,7 +118,7 @@ async function installGradleVersion(versionInfo: GradleVersionInfo): Promise<str
 }
 
 async function installGradleVersionAtLeast(versionInfo: GradleVersionInfo): Promise<string> {
-    return core.group(`Provision Gradle >= ${versionInfo.version}`, async () => {
+    return exec.group(`Provision Gradle >= ${versionInfo.version}`, async () => {
         const gradleOnPath = await findGradleVersionOnPath()
         if (gradleOnPath && versionIsAtLeast(gradleOnPath.version, versionInfo.version)) {
             log.info(

--- a/sources/src/setup-gradle.ts
+++ b/sources/src/setup-gradle.ts
@@ -1,4 +1,3 @@
-import * as exec from '@actions/exec'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
@@ -17,7 +16,7 @@ import {
     getWorkspaceDirectory
 } from './configuration'
 import * as wrapperValidator from './wrapper-validation/wrapper-validator'
-import {log, state} from './env'
+import {exec, log, state} from './env'
 
 const GRADLE_SETUP_VAR = 'GRADLE_BUILD_ACTION_SETUP_COMPLETED'
 const USER_HOME = 'USER_HOME'

--- a/sources/src/wrapper-validation/wrapper-validator.ts
+++ b/sources/src/wrapper-validation/wrapper-validator.ts
@@ -1,10 +1,8 @@
-import * as core from '@actions/core'
-
 import {WrapperValidationConfig} from '../configuration'
 import {ChecksumCache} from './cache'
 import {findInvalidWrapperJars} from './validate'
 import {JobFailure} from '../errors'
-import {log} from '../env'
+import {exec, log} from '../env'
 
 export async function validateWrappers(
     config: WrapperValidationConfig,
@@ -26,7 +24,7 @@ export async function validateWrappers(
         previouslyValidatedChecksums
     )
     if (result.isValid()) {
-        await core.group('All Gradle Wrapper jars are valid', async () => {
+        await exec.group('All Gradle Wrapper jars are valid', async () => {
             log.debug(`Loaded previously validated checksums from cache: ${previouslyValidatedChecksums.join(', ')}`)
             log.info(result.toDisplayString())
         })

--- a/sources/test/jest/cache-cleanup.test.ts
+++ b/sources/test/jest/cache-cleanup.test.ts
@@ -1,9 +1,8 @@
-import * as exec from '@actions/exec'
-import * as core from '@actions/core'
 import * as glob from '@actions/glob'
 import fs from 'fs'
 import path from 'path'
 import {CacheCleaner} from '../../src/caching/cache-cleaner'
+import {exec} from '../../src/env'
 
 import { configureTestEnv } from './test-env'
 configureTestEnv()

--- a/sources/test/jest/test-env.ts
+++ b/sources/test/jest/test-env.ts
@@ -1,5 +1,10 @@
-import { state } from '../../src/env'
-import { CIStateImplementation } from '../../src/env/state'
+import {exec, CIExecOptions, log, state} from '../../src/env'
+import {CIStateImplementation} from '../../src/env/state'
+
+import util from 'util'
+import {exec as cp_exec} from 'child_process'
+
+const pexec = util.promisify(cp_exec);
 
 class TestStateImplementation implements CIStateImplementation {
     readonly state: Record<string, string> = {}
@@ -50,6 +55,45 @@ function setupState(): void {
     state.setImpl(testState)
 }
 
+function setupExec(): void {
+    exec.setImpl(
+        {
+            group: <R>(name: string, fn: () => Promise<R>): Promise<R> => {
+                try {
+                    log.debug(`::group-enter:: ${name}`)
+                    return fn()
+                } finally {
+                    log.debug(`::group-exit:: ${name}`)
+                }
+            },
+
+            run: async (command: string, args?: string[], options?: CIExecOptions): Promise<void> => {
+                await pexec([command, ...(args ?? [])].join(' '), options)
+            },
+
+            exec: async (command: string, args?: string[], options?: CIExecOptions): Promise<number> => {
+                try {
+                    await pexec([command, ...(args ?? [])].join(' '), options)
+                    return 0
+                } catch (error) {
+                    log.warn(`Failed to run ${command}: ${error}`)
+                    return 1
+                }
+            },
+
+            getExecOutput: async (
+                command: string,
+                args?: string[],
+                options?: CIExecOptions
+            ): Promise<{stdout: string; stderr: string}> => {
+                const result = await pexec([command, ...(args ?? [])].join(' '), options)
+                return {stdout: result.stdout.toString(), stderr: result.stderr.toString()}
+            }
+        }
+    )
+}
+
 export const configureTestEnv = (): void => {
     setupState()
+    setupExec()
 }


### PR DESCRIPTION
There is no functional changes present, child processes calls are moved behind small wrapper class to provide a simple abstraction to be replaced. 

Currently, we implement this in terms of `Github Actions` -- for obvious reasons. In the future, this enables implementation in other, non-Github CI environments. 

Part of gradle/actions#502.