### PR TITLE
MultiCI: Abstract Github Action cache access behind type

### DIFF
--- a/sources/src/actions/github-actions-env.ts
+++ b/sources/src/actions/github-actions-env.ts
@@ -4,8 +4,6 @@ import * as ghExec from '@actions/exec'
 
 import {
     cache,
-    CacheEntryAlreadyExistsError,
-    CacheValidationError,
     CICacheEntry,
     exec,
     CIExecOptions,
@@ -76,17 +74,17 @@ function setupCache(): void {
         isAvailable: ghCache.isFeatureAvailable,
 
         saveCache: async (paths: string[], key: string): Promise<CICacheEntry> => {
-            try {
-                return await ghCache.saveCache(paths, key)
-            } catch (error) {
-                if (error instanceof ghCache.ReserveCacheError) {
-                    throw new CacheEntryAlreadyExistsError(error.message)
-                } else if (error instanceof ghCache.ValidationError) {
-                    throw new CacheValidationError(error.message)
-                } else {
-                    throw error
-                }
-            }
+            // try {
+            return await ghCache.saveCache(paths, key)
+            // } catch (error) {
+            //     if (error instanceof ghCache.ReserveCacheError) {
+            //         throw new CacheEntryAlreadyExistsError(error.message)
+            //     } else if (error instanceof ghCache.ValidationError) {
+            //         throw new CacheValidationError(error.message)
+            //     } else {
+            //         throw error
+            //     }
+            // }
         },
 
         restoreCache: ghCache.restoreCache

--- a/sources/src/actions/github-actions-env.ts
+++ b/sources/src/actions/github-actions-env.ts
@@ -9,7 +9,9 @@ import {
     CIExecOptions,
     log,
     LogLevel,
-    state
+    state,
+    CacheEntryAlreadyExistsError,
+    CacheValidationError
 } from '../env'
 
 function setupState(): void {
@@ -74,17 +76,17 @@ function setupCache(): void {
         isAvailable: ghCache.isFeatureAvailable,
 
         saveCache: async (paths: string[], key: string): Promise<CICacheEntry> => {
-            // try {
-            return await ghCache.saveCache(paths, key)
-            // } catch (error) {
-            //     if (error instanceof ghCache.ReserveCacheError) {
-            //         throw new CacheEntryAlreadyExistsError(error.message)
-            //     } else if (error instanceof ghCache.ValidationError) {
-            //         throw new CacheValidationError(error.message)
-            //     } else {
-            //         throw error
-            //     }
-            // }
+            try {
+                return await ghCache.saveCache(paths, key)
+            } catch (error) {
+                if (error instanceof ghCache.ReserveCacheError) {
+                    throw new CacheEntryAlreadyExistsError(error.message)
+                } else if (error instanceof ghCache.ValidationError) {
+                    throw new CacheValidationError(error.message)
+                } else {
+                    throw error
+                }
+            }
         },
 
         restoreCache: ghCache.restoreCache

--- a/sources/src/actions/github-actions-env.ts
+++ b/sources/src/actions/github-actions-env.ts
@@ -1,7 +1,18 @@
 import * as core from '@actions/core'
+import * as ghCache from '@actions/cache'
 import * as ghExec from '@actions/exec'
 
-import {exec, CIExecOptions, log, LogLevel, state} from '../env'
+import {
+    cache,
+    CacheEntryAlreadyExistsError,
+    CacheValidationError,
+    CICacheEntry,
+    exec,
+    CIExecOptions,
+    log,
+    LogLevel,
+    state
+} from '../env'
 
 function setupState(): void {
     state.setImpl({
@@ -60,8 +71,31 @@ function setupExec(): void {
     })
 }
 
+function setupCache(): void {
+    cache.setImpl({
+        isAvailable: ghCache.isFeatureAvailable,
+
+        saveCache: async (paths: string[], key: string): Promise<CICacheEntry> => {
+            try {
+                return await ghCache.saveCache(paths, key)
+            } catch (error) {
+                if (error instanceof ghCache.ReserveCacheError) {
+                    throw new CacheEntryAlreadyExistsError(error.message)
+                } else if (error instanceof ghCache.ValidationError) {
+                    throw new CacheValidationError(error.message)
+                } else {
+                    throw error
+                }
+            }
+        },
+
+        restoreCache: ghCache.restoreCache
+    })
+}
+
 export const configureGithubEnv = (): void => {
     setupState()
     setupLogger()
     setupExec()
+    setupCache()
 }

--- a/sources/src/caching/cache-reporting.ts
+++ b/sources/src/caching/cache-reporting.ts
@@ -1,4 +1,4 @@
-import * as cache from '@actions/cache'
+import {cache} from '../env'
 
 export const DEFAULT_CACHE_ENABLED_REASON = `[Cache was enabled](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#caching-build-state-between-jobs). Action attempted to both restore and save the Gradle User Home.`
 
@@ -39,7 +39,7 @@ export class CacheListener {
     }
 
     get cacheStatus(): string {
-        if (!cache.isFeatureAvailable()) return 'not available'
+        if (!cache.isAvailable()) return 'not available'
         if (this.cacheDisabled) return 'disabled'
         if (this.cacheWriteOnly) return 'write-only'
         if (this.cacheReadOnly) return 'read-only'

--- a/sources/src/caching/cache-utils.ts
+++ b/sources/src/caching/cache-utils.ts
@@ -1,9 +1,16 @@
-import * as ghCache from '@actions/cache'
 import * as crypto from 'crypto'
 import * as path from 'path'
 import * as fs from 'fs'
 
-import {cache, CICacheEntry, exec, log, RemoteCacheDownloadOptions} from '../env'
+import {
+    cache,
+    CacheEntryAlreadyExistsError,
+    CacheValidationError,
+    CICacheEntry,
+    exec,
+    log,
+    RemoteCacheDownloadOptions
+} from '../env'
 import {CacheEntryListener} from './cache-reporting'
 
 const SEGMENT_DOWNLOAD_TIMEOUT_VAR = 'SEGMENT_DOWNLOAD_TIMEOUT_MINS'
@@ -56,7 +63,7 @@ export async function saveCache(cachePath: string[], cacheKey: string, listener:
         listener.markSaved(savedEntry.key, savedEntry.size, saveTime)
         log.info(`Saved cache entry with key ${cacheKey} from ${cachePath.join()} in ${saveTime}ms`)
     } catch (error) {
-        if (error instanceof ghCache.ReserveCacheError) {
+        if (error instanceof CacheEntryAlreadyExistsError) {
             listener.markAlreadyExists(cacheKey)
         } else {
             listener.markNotSaved((error as Error).message)
@@ -66,11 +73,11 @@ export async function saveCache(cachePath: string[], cacheKey: string, listener:
 }
 
 export function handleCacheFailure(error: unknown, message: string): void {
-    if (error instanceof ghCache.ValidationError) {
+    if (error instanceof CacheValidationError) {
         // Fail on cache validation errors
         throw error
     }
-    if (error instanceof ghCache.ReserveCacheError) {
+    if (error instanceof CacheEntryAlreadyExistsError) {
         // Reserve cache errors are expected if the artifact has been previously cached
         log.info(`${message}: ${error}`)
     } else {

--- a/sources/src/caching/cache-utils.ts
+++ b/sources/src/caching/cache-utils.ts
@@ -1,10 +1,8 @@
-import * as cache from '@actions/cache'
-
 import * as crypto from 'crypto'
 import * as path from 'path'
 import * as fs from 'fs'
 
-import {exec, log} from '../env'
+import {cache, CacheEntryAlreadyExistsError, CacheValidationError, CICacheEntry, exec, log} from '../env'
 import {CacheEntryListener} from './cache-reporting'
 
 const SEGMENT_DOWNLOAD_TIMEOUT_VAR = 'SEGMENT_DOWNLOAD_TIMEOUT_MINS'
@@ -27,7 +25,7 @@ export async function restoreCache(
     cacheKey: string,
     cacheRestoreKeys: string[],
     listener: CacheEntryListener
-): Promise<cache.CacheEntry | undefined> {
+): Promise<CICacheEntry | undefined> {
     listener.markRequested(cacheKey, cacheRestoreKeys)
     try {
         const startTime = Date.now()
@@ -57,7 +55,7 @@ export async function saveCache(cachePath: string[], cacheKey: string, listener:
         listener.markSaved(savedEntry.key, savedEntry.size, saveTime)
         log.info(`Saved cache entry with key ${cacheKey} from ${cachePath.join()} in ${saveTime}ms`)
     } catch (error) {
-        if (error instanceof cache.ReserveCacheError) {
+        if (error instanceof CacheEntryAlreadyExistsError) {
             listener.markAlreadyExists(cacheKey)
         } else {
             listener.markNotSaved((error as Error).message)
@@ -67,11 +65,11 @@ export async function saveCache(cachePath: string[], cacheKey: string, listener:
 }
 
 export function handleCacheFailure(error: unknown, message: string): void {
-    if (error instanceof cache.ValidationError) {
+    if (error instanceof CacheValidationError) {
         // Fail on cache validation errors
         throw error
     }
-    if (error instanceof cache.ReserveCacheError) {
+    if (error instanceof CacheEntryAlreadyExistsError) {
         // Reserve cache errors are expected if the artifact has been previously cached
         log.info(`${message}: ${error}`)
     } else {

--- a/sources/src/caching/cache-utils.ts
+++ b/sources/src/caching/cache-utils.ts
@@ -1,8 +1,9 @@
+import * as ghCache from '@actions/cache'
 import * as crypto from 'crypto'
 import * as path from 'path'
 import * as fs from 'fs'
 
-import {cache, CacheEntryAlreadyExistsError, CacheValidationError, CICacheEntry, exec, log} from '../env'
+import {cache, CICacheEntry, exec, log, RemoteCacheDownloadOptions} from '../env'
 import {CacheEntryListener} from './cache-reporting'
 
 const SEGMENT_DOWNLOAD_TIMEOUT_VAR = 'SEGMENT_DOWNLOAD_TIMEOUT_MINS'
@@ -30,7 +31,7 @@ export async function restoreCache(
     try {
         const startTime = Date.now()
         // Only override the read timeout if the SEGMENT_DOWNLOAD_TIMEOUT_MINS env var has NOT been set
-        const cacheRestoreOptions = process.env[SEGMENT_DOWNLOAD_TIMEOUT_VAR]
+        const cacheRestoreOptions: RemoteCacheDownloadOptions = process.env[SEGMENT_DOWNLOAD_TIMEOUT_VAR]
             ? {}
             : {segmentTimeoutInMs: SEGMENT_DOWNLOAD_TIMEOUT_DEFAULT}
         const restoredEntry = await cache.restoreCache(cachePath, cacheKey, cacheRestoreKeys, cacheRestoreOptions)
@@ -55,7 +56,7 @@ export async function saveCache(cachePath: string[], cacheKey: string, listener:
         listener.markSaved(savedEntry.key, savedEntry.size, saveTime)
         log.info(`Saved cache entry with key ${cacheKey} from ${cachePath.join()} in ${saveTime}ms`)
     } catch (error) {
-        if (error instanceof CacheEntryAlreadyExistsError) {
+        if (error instanceof ghCache.ReserveCacheError) {
             listener.markAlreadyExists(cacheKey)
         } else {
             listener.markNotSaved((error as Error).message)
@@ -65,11 +66,11 @@ export async function saveCache(cachePath: string[], cacheKey: string, listener:
 }
 
 export function handleCacheFailure(error: unknown, message: string): void {
-    if (error instanceof CacheValidationError) {
+    if (error instanceof ghCache.ValidationError) {
         // Fail on cache validation errors
         throw error
     }
-    if (error instanceof CacheEntryAlreadyExistsError) {
+    if (error instanceof ghCache.ReserveCacheError) {
         // Reserve cache errors are expected if the artifact has been previously cached
         log.info(`${message}: ${error}`)
     } else {

--- a/sources/src/configuration.ts
+++ b/sources/src/configuration.ts
@@ -1,8 +1,7 @@
 import * as github from '@actions/github'
-import * as cache from '@actions/cache'
 import * as deprecator from './deprecation-collector'
 import {SUMMARY_ENV_VAR} from '@actions/core/lib/summary'
-import {log, state} from './env'
+import {cache, log, state} from './env'
 
 import path from 'path'
 
@@ -102,7 +101,7 @@ export enum DependencyGraphOption {
 
 export class CacheConfig {
     isCacheDisabled(): boolean {
-        if (!cache.isFeatureAvailable()) {
+        if (!cache.isAvailable()) {
             return true
         }
 

--- a/sources/src/env/cache.ts
+++ b/sources/src/env/cache.ts
@@ -1,0 +1,82 @@
+export interface CICacheImplementation {
+    /**
+     * True if the cache is available.
+     */
+    isAvailable(): boolean
+
+    /**
+     * Restores cache from keys
+     *
+     * @param paths a list of file paths to restore from the cache
+     * @param primaryKey an explicit key for restoring the cache. Lookup is done with prefix matching.
+     * @param restoreKeys an optional ordered list of keys to use for restoring the cache if no cache hit occurred for primaryKey
+     * @param downloadOptions cache download options
+     * @param enableCrossOsArchive an optional boolean enabled to restore on windows any cache created on any platform
+     * @returns string returns the key for the cache hit, otherwise returns undefined
+     */
+    restoreCache(
+        paths: string[],
+        primaryKey: string,
+        restoreKeys?: string[],
+        options?: RemoteCacheDownloadOptions
+    ): Promise<CICacheEntry | undefined>
+
+    /**
+     * Saves a list of files with the specified key
+     *
+     * @param paths a list of file paths to be cached
+     * @param key an explicit key for restoring the cache
+     * @param enableCrossOsArchive an optional boolean enabled to save cache on windows which could be restored on any platform
+     * @param options cache upload options
+     * @returns number returns cacheId if the cache was saved successfully and throws an error if save fails
+     */
+    saveCache(paths: string[], key: string): Promise<CICacheEntry>
+}
+
+export class CICache implements CICacheImplementation {
+    private impl!: CICacheImplementation
+
+    setImpl(impl: CICacheImplementation): void {
+        this.impl = impl
+    }
+
+    isAvailable(): boolean {
+        return this.impl.isAvailable()
+    }
+
+    async restoreCache(
+        paths: string[],
+        primaryKey: string,
+        restoreKeys?: string[],
+        options?: RemoteCacheDownloadOptions
+    ): Promise<CICacheEntry | undefined> {
+        return await this.impl.restoreCache(paths, primaryKey, restoreKeys, options)
+    }
+
+    async saveCache(paths: string[], key: string): Promise<CICacheEntry> {
+        return await this.impl.saveCache(paths, key)
+    }
+}
+
+/**
+ * Thrown when a validation error occurs during caching.
+ */
+export class CacheValidationError extends Error {}
+
+/**
+ * Thrown when a cache entry already exists and can not be written to.
+ */
+export class CacheEntryAlreadyExistsError extends Error {}
+
+/**
+ * Options to control cache download
+ */
+export interface RemoteCacheDownloadOptions {
+    /** optional cache download timeout.  defaults to 2 minutes */
+    segmentTimeoutInMs?: number
+}
+
+export interface CICacheEntry {
+    key: string
+    size?: number
+}

--- a/sources/src/env/index.ts
+++ b/sources/src/env/index.ts
@@ -1,3 +1,4 @@
+import {CICache} from './cache'
 import {CIExec} from './execution'
 import {Logger} from './logging'
 import {CIState} from './state'
@@ -8,5 +9,8 @@ export const state = new CIState()
 export {LogLevel} from './logging'
 export const log = new Logger()
 
+export {CIExecOptions} from './execution'
 export const exec = new CIExec()
-export {CIExecImplementation, CIExecOptions} from './execution'
+
+export {CICacheEntry, RemoteCacheDownloadOptions, CacheEntryAlreadyExistsError, CacheValidationError} from './cache'
+export const cache = new CICache()

--- a/sources/src/execution/provision.ts
+++ b/sources/src/execution/provision.ts
@@ -3,14 +3,13 @@ import * as os from 'os'
 import * as path from 'path'
 import * as httpm from '@actions/http-client'
 import * as core from '@actions/core'
-import * as cache from '@actions/cache'
 import * as toolCache from '@actions/tool-cache'
 
 import {findGradleVersionOnPath, versionIsAtLeast} from './gradle'
 import * as gradlew from './gradlew'
 import {handleCacheFailure} from '../caching/cache-utils'
 import {CacheConfig} from '../configuration'
-import {exec, log} from '../env'
+import {cache, exec, log} from '../env'
 
 const gradleVersionsBaseUrl = 'https://services.gradle.org/versions'
 

--- a/sources/test/jest/test-env.ts
+++ b/sources/test/jest/test-env.ts
@@ -1,10 +1,23 @@
-import {exec, CIExecOptions, log, state} from '../../src/env'
-import {CIStateImplementation} from '../../src/env/state'
+import {
+    cache, 
+    CacheEntryAlreadyExistsError,
+    CICacheEntry,
+    RemoteCacheDownloadOptions, 
+    exec, 
+    CIExecOptions, 
+    log, 
+    state
+} from '../../src/env'
 
 import util from 'util'
 import {exec as cp_exec} from 'child_process'
+import {readFile as fs_readFile, writeFile as fs_writeFile} from 'fs'
+import { CIStateImplementation } from '../../src/env/state'
+import { CICacheImplementation } from '../../src/env/cache'
 
 const pexec = util.promisify(cp_exec);
+const readFile = util.promisify(fs_readFile)
+const writeFile = util.promisify(fs_writeFile)
 
 class TestStateImplementation implements CIStateImplementation {
     readonly state: Record<string, string> = {}
@@ -49,7 +62,7 @@ class TestStateImplementation implements CIStateImplementation {
     }
 }
 
-const testState = new TestStateImplementation()
+export const testState = new TestStateImplementation()
 
 function setupState(): void {
     state.setImpl(testState)
@@ -93,7 +106,77 @@ function setupExec(): void {
     )
 }
 
+class TestCacheImpl implements CICacheImplementation {
+    private readonly cacheContent: Record<string, Record<string, Uint8Array>> = {}
+
+    private _isAvailable: boolean = true
+
+    isAvailable(): boolean {
+        return this._isAvailable
+    }
+
+    enable(): void {
+        this._isAvailable = true
+    }
+
+    disable(): void {
+        this._isAvailable = false
+    }
+
+    async saveCache(paths: string[], key: string): Promise<CICacheEntry> {
+        if (this.cacheContent[key]) {
+            throw new CacheEntryAlreadyExistsError(`Cache entry with key ${key} already exists`)
+        }
+
+        const fileContents = paths.map(async (path) => {
+            return await readFile(path)
+        })
+
+        let size = 0
+        const value: Record<string, Buffer<ArrayBufferLike>> = {}
+        for (const [path, contentsPromise] of zip(paths, fileContents)) {
+            const contents = await contentsPromise
+            value[path] = contents
+            size += contents.byteLength
+        }
+
+        this.cacheContent[key] = value
+        return { key, size }
+    }
+
+    async restoreCache(paths: string[], primaryKey: string, restoreKeys?: string[], options?: RemoteCacheDownloadOptions): Promise<CICacheEntry | undefined> {
+        for (const key in [primaryKey, ...(restoreKeys ?? [])]) {
+            const cacheEntry = this.cacheContent[key]
+            // Look up is by hierarchal keys, so its possible the key does not exist.
+            if (!cacheEntry) continue 
+            
+            // Write all the cached files to disk in parallel
+            await Promise.all(paths.map(async (path) => {
+                const content = cacheEntry[path]
+                if (content) {
+                    await writeFile(path, content)
+                }
+            }))
+
+            return { key: primaryKey, size: Object.values(cacheEntry).reduce((acc, val) => acc + val.byteLength, 0) }
+        }
+
+        return undefined
+    }
+}
+
+export const testCache = new TestCacheImpl()
+
+function setupCache(): void {
+    cache.setImpl(testCache)
+}
+
 export const configureTestEnv = (): void => {
     setupState()
     setupExec()
+    setupCache()
+}
+
+function zip<A, B>(a: A[], b: B[]): [A, B][] {
+    return a.map((k, i) => [k, b[i]]);
 }


### PR DESCRIPTION
There is no functional changes present, access is moved behind small wrapper class to provide a simple abstraction to be replaced. 

Currently, we implement this in terms of `Github Actions` -- for obvious reasons. In the future, this enables implementation in other, non-Github CI environments. 

Part of gradle/actions#502.