### PR TITLE
MultiCI: Replace all usages of `core` state reading

### DIFF
--- a/sources/src/caching/cache-utils.ts
+++ b/sources/src/caching/cache-utils.ts
@@ -6,13 +6,14 @@ import * as crypto from 'crypto'
 import * as path from 'path'
 import * as fs from 'fs'
 
+import {state} from '../env/state'
 import {CacheEntryListener} from './cache-reporting'
 
 const SEGMENT_DOWNLOAD_TIMEOUT_VAR = 'SEGMENT_DOWNLOAD_TIMEOUT_MINS'
 const SEGMENT_DOWNLOAD_TIMEOUT_DEFAULT = 10 * 60 * 1000 // 10 minutes
 
 export function isCacheDebuggingEnabled(): boolean {
-    if (core.isDebug()) {
+    if (state.isDebug()) {
         return true
     }
     return process.env['GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED'] ? true : false

--- a/sources/src/caching/cache-utils.ts
+++ b/sources/src/caching/cache-utils.ts
@@ -6,7 +6,7 @@ import * as crypto from 'crypto'
 import * as path from 'path'
 import * as fs from 'fs'
 
-import {state} from '../env/state'
+import {state} from '../env'
 import {CacheEntryListener} from './cache-reporting'
 
 const SEGMENT_DOWNLOAD_TIMEOUT_VAR = 'SEGMENT_DOWNLOAD_TIMEOUT_MINS'

--- a/sources/src/caching/caches.ts
+++ b/sources/src/caching/caches.ts
@@ -25,7 +25,7 @@ export async function restore(
         core.info('Cache only restored on first action step.')
         return
     }
-    state.exportVariable(CACHE_RESTORED_VAR, true.toString())
+    state.exportVariable(CACHE_RESTORED_VAR, true)
 
     const gradleStateCache = new GradleUserHomeCache(userHome, gradleUserHome, cacheConfig)
 

--- a/sources/src/caching/caches.ts
+++ b/sources/src/caching/caches.ts
@@ -10,6 +10,7 @@ import {CacheCleaner} from './cache-cleaner'
 import {DaemonController} from '../daemon-controller'
 import {CacheConfig} from '../configuration'
 import {BuildResults} from '../build-results'
+import {state} from '../env/state'
 
 const CACHE_RESTORED_VAR = 'GRADLE_BUILD_ACTION_CACHE_RESTORED'
 
@@ -24,7 +25,7 @@ export async function restore(
         core.info('Cache only restored on first action step.')
         return
     }
-    core.exportVariable(CACHE_RESTORED_VAR, true)
+    state.exportVariable(CACHE_RESTORED_VAR, true.toString())
 
     const gradleStateCache = new GradleUserHomeCache(userHome, gradleUserHome, cacheConfig)
 
@@ -49,7 +50,7 @@ export async function restore(
 
     gradleStateCache.init()
     // Mark the state as restored so that post-action will perform save.
-    core.saveState(CACHE_RESTORED_VAR, true)
+    state.save(CACHE_RESTORED_VAR, true.toString())
 
     if (cacheConfig.isCacheCleanupEnabled()) {
         core.info('Preparing cache for cleanup.')
@@ -81,7 +82,7 @@ export async function save(
         return
     }
 
-    if (!core.getState(CACHE_RESTORED_VAR)) {
+    if (!state.get(CACHE_RESTORED_VAR)) {
         core.info('Cache will not be saved: not restored in main action step.')
         return
     }

--- a/sources/src/caching/caches.ts
+++ b/sources/src/caching/caches.ts
@@ -10,7 +10,7 @@ import {CacheCleaner} from './cache-cleaner'
 import {DaemonController} from '../daemon-controller'
 import {CacheConfig} from '../configuration'
 import {BuildResults} from '../build-results'
-import {state} from '../env/state'
+import {state} from '../env'
 
 const CACHE_RESTORED_VAR = 'GRADLE_BUILD_ACTION_CACHE_RESTORED'
 

--- a/sources/src/caching/caches.ts
+++ b/sources/src/caching/caches.ts
@@ -50,7 +50,7 @@ export async function restore(
 
     gradleStateCache.init()
     // Mark the state as restored so that post-action will perform save.
-    state.save(CACHE_RESTORED_VAR, true.toString())
+    state.save(CACHE_RESTORED_VAR, true)
 
     if (cacheConfig.isCacheCleanupEnabled()) {
         core.info('Preparing cache for cleanup.')

--- a/sources/src/caching/gradle-user-home-cache.ts
+++ b/sources/src/caching/gradle-user-home-cache.ts
@@ -10,6 +10,7 @@ import {saveCache, restoreCache, cacheDebug, isCacheDebuggingEnabled, tryDelete}
 import {CacheConfig, ACTION_METADATA_DIR} from '../configuration'
 import {GradleHomeEntryExtractor, ConfigurationCacheEntryExtractor} from './gradle-home-extry-extractor'
 import {getPredefinedToolchains, mergeToolchainContent, readResourceFileAsString} from './gradle-user-home-utils'
+import {state} from '../env/state'
 
 const RESTORED_CACHE_KEY_KEY = 'restored-cache-key'
 
@@ -33,7 +34,7 @@ export class GradleUserHomeCache {
         // Export the GRADLE_ENCRYPTION_KEY variable if provided
         const encryptionKey = this.cacheConfig.getCacheEncryptionKey()
         if (encryptionKey) {
-            core.exportVariable('GRADLE_ENCRYPTION_KEY', encryptionKey)
+            state.exportVariable('GRADLE_ENCRYPTION_KEY', encryptionKey)
         }
     }
 
@@ -67,7 +68,7 @@ export class GradleUserHomeCache {
             return
         }
 
-        core.saveState(RESTORED_CACHE_KEY_KEY, cacheResult.key)
+        state.save(RESTORED_CACHE_KEY_KEY, cacheResult.key)
 
         try {
             await this.afterRestore(listener)
@@ -96,7 +97,7 @@ export class GradleUserHomeCache {
      */
     async save(listener: CacheListener): Promise<void> {
         const cacheKey = generateCacheKey(this.cacheName, this.cacheConfig).key
-        const restoredCacheKey = core.getState(RESTORED_CACHE_KEY_KEY)
+        const restoredCacheKey = state.get(RESTORED_CACHE_KEY_KEY)
         const gradleHomeEntryListener = listener.entry(this.cacheDescription)
 
         if (restoredCacheKey && cacheKey === restoredCacheKey) {
@@ -191,7 +192,7 @@ export class GradleUserHomeCache {
         // Copy the default toolchain definitions to `~/.m2/toolchains.xml`
         this.registerToolchains()
 
-        if (core.isDebug()) {
+        if (state.isDebug()) {
             this.configureInfoLogLevel()
         }
     }
@@ -260,7 +261,7 @@ export class GradleUserHomeCache {
      * this method will give a detailed report of the Gradle User Home contents.
      */
     private async debugReportGradleUserHomeSize(label: string): Promise<void> {
-        if (!isCacheDebuggingEnabled() && !core.isDebug()) {
+        if (!isCacheDebuggingEnabled() && !state.isDebug()) {
             return
         }
         if (!fs.existsSync(this.gradleUserHome)) {

--- a/sources/src/caching/gradle-user-home-cache.ts
+++ b/sources/src/caching/gradle-user-home-cache.ts
@@ -10,7 +10,7 @@ import {saveCache, restoreCache, cacheDebug, isCacheDebuggingEnabled, tryDelete}
 import {CacheConfig, ACTION_METADATA_DIR} from '../configuration'
 import {GradleHomeEntryExtractor, ConfigurationCacheEntryExtractor} from './gradle-home-extry-extractor'
 import {getPredefinedToolchains, mergeToolchainContent, readResourceFileAsString} from './gradle-user-home-utils'
-import {state} from '../env/state'
+import {state} from '../env'
 
 const RESTORED_CACHE_KEY_KEY = 'restored-cache-key'
 

--- a/sources/src/configuration.ts
+++ b/sources/src/configuration.ts
@@ -3,7 +3,7 @@ import * as github from '@actions/github'
 import * as cache from '@actions/cache'
 import * as deprecator from './deprecation-collector'
 import {SUMMARY_ENV_VAR} from '@actions/core/lib/summary'
-import {state} from './env/state'
+import {state} from './env'
 
 import path from 'path'
 

--- a/sources/src/configuration.ts
+++ b/sources/src/configuration.ts
@@ -3,6 +3,7 @@ import * as github from '@actions/github'
 import * as cache from '@actions/cache'
 import * as deprecator from './deprecation-collector'
 import {SUMMARY_ENV_VAR} from '@actions/core/lib/summary'
+import {state} from './env/state'
 
 import path from 'path'
 
@@ -12,7 +13,7 @@ export const ACTION_METADATA_DIR = '.setup-gradle'
 
 export class DependencyGraphConfig {
     getDependencyGraphOption(): DependencyGraphOption {
-        const val = core.getInput('dependency-graph')
+        const val = state.getInput('dependency-graph')
         switch (val.toLowerCase().trim()) {
             case 'disabled':
                 return DependencyGraphOption.Disabled
@@ -35,7 +36,7 @@ export class DependencyGraphConfig {
     }
 
     getArtifactRetentionDays(): number {
-        const val = core.getInput('artifact-retention-days')
+        const val = state.getInput('artifact-retention-days')
         return parseNumericInput('artifact-retention-days', val, 0)
         // Zero indicates that the default repository settings should be used
     }
@@ -45,7 +46,7 @@ export class DependencyGraphConfig {
     }
 
     getReportDirectory(): string {
-        const param = core.getInput('dependency-graph-report-dir')
+        const param = state.getInput('dependency-graph-report-dir')
         return path.resolve(getWorkspaceDirectory(), param)
     }
 
@@ -153,7 +154,7 @@ export class CacheConfig {
             return legacyVal ? CacheCleanupOption.Always : CacheCleanupOption.Never
         }
 
-        const val = core.getInput('cache-cleanup')
+        const val = state.getInput('cache-cleanup')
         switch (val.toLowerCase().trim()) {
             case 'always':
                 return CacheCleanupOption.Always
@@ -168,15 +169,15 @@ export class CacheConfig {
     }
 
     getCacheEncryptionKey(): string {
-        return core.getInput('cache-encryption-key')
+        return state.getInput('cache-encryption-key')
     }
 
     getCacheIncludes(): string[] {
-        return core.getMultilineInput('gradle-home-cache-includes')
+        return state.getMultilineInput('gradle-home-cache-includes')
     }
 
     getCacheExcludes(): string[] {
-        return core.getMultilineInput('gradle-home-cache-excludes')
+        return state.getMultilineInput('gradle-home-cache-excludes')
     }
 }
 
@@ -220,7 +221,7 @@ export class SummaryConfig {
     }
 
     private parseJobSummaryOption(paramName: string): JobSummaryOption {
-        const val = core.getInput(paramName)
+        const val = state.getInput(paramName)
         switch (val.toLowerCase().trim()) {
             case 'never':
                 return JobSummaryOption.Never
@@ -250,16 +251,16 @@ export class BuildScanConfig {
     }
 
     getBuildScanTermsOfUseUrl(): string {
-        return core.getInput('build-scan-terms-of-use-url')
+        return state.getInput('build-scan-terms-of-use-url')
     }
 
     getBuildScanTermsOfUseAgree(): string {
-        return core.getInput('build-scan-terms-of-use-agree')
+        return state.getInput('build-scan-terms-of-use-agree')
     }
 
     getDevelocityAccessKey(): string {
         return (
-            core.getInput('develocity-access-key') ||
+            state.getInput('develocity-access-key') ||
             process.env[BuildScanConfig.DevelocityAccessKeyEnvVar] ||
             process.env[BuildScanConfig.GradleEnterpriseAccessKeyEnvVar] ||
             ''
@@ -267,7 +268,7 @@ export class BuildScanConfig {
     }
 
     getDevelocityTokenExpiry(): string {
-        return core.getInput('develocity-token-expiry')
+        return state.getInput('develocity-token-expiry')
     }
 
     getDevelocityInjectionEnabled(): boolean | undefined {
@@ -275,7 +276,7 @@ export class BuildScanConfig {
     }
 
     getDevelocityUrl(): string {
-        return core.getInput('develocity-url')
+        return state.getInput('develocity-url')
     }
 
     getDevelocityAllowUntrustedServer(): boolean | undefined {
@@ -291,23 +292,23 @@ export class BuildScanConfig {
     }
 
     getDevelocityPluginVersion(): string {
-        return core.getInput('develocity-plugin-version')
+        return state.getInput('develocity-plugin-version')
     }
 
     getDevelocityCcudPluginVersion(): string {
-        return core.getInput('develocity-ccud-plugin-version')
+        return state.getInput('develocity-ccud-plugin-version')
     }
 
     getGradlePluginRepositoryUrl(): string {
-        return core.getInput('gradle-plugin-repository-url')
+        return state.getInput('gradle-plugin-repository-url')
     }
 
     getGradlePluginRepositoryUsername(): string {
-        return core.getInput('gradle-plugin-repository-username')
+        return state.getInput('gradle-plugin-repository-username')
     }
 
     getGradlePluginRepositoryPassword(): string {
-        return core.getInput('gradle-plugin-repository-password')
+        return state.getInput('gradle-plugin-repository-password')
     }
 
     private verifyTermsOfUseAgreement(): boolean {
@@ -327,12 +328,12 @@ export class BuildScanConfig {
 
 export class GradleExecutionConfig {
     getGradleVersion(): string {
-        return core.getInput('gradle-version')
+        return state.getInput('gradle-version')
     }
 
     getBuildRootDirectory(): string {
         const baseDirectory = getWorkspaceDirectory()
-        const buildRootDirectoryInput = core.getInput('build-root-directory')
+        const buildRootDirectoryInput = state.getInput('build-root-directory')
         const resolvedBuildRootDirectory =
             buildRootDirectoryInput === ''
                 ? path.resolve(baseDirectory)
@@ -341,15 +342,15 @@ export class GradleExecutionConfig {
     }
 
     getDependencyResolutionTask(): string {
-        return core.getInput('dependency-resolution-task') || ':ForceDependencyResolutionPlugin_resolveAllDependencies'
+        return state.getInput('dependency-resolution-task') || ':ForceDependencyResolutionPlugin_resolveAllDependencies'
     }
 
     getAdditionalArguments(): string {
-        return core.getInput('additional-arguments')
+        return state.getInput('additional-arguments')
     }
 
     verifyNoArguments(): void {
-        const input = core.getInput('arguments')
+        const input = state.getInput('arguments')
         if (input.length !== 0) {
             deprecator.failOnUseOfRemovedFeature(
                 `The 'arguments' parameter is no longer supported for ${getActionId()}`,
@@ -371,11 +372,11 @@ export class WrapperValidationConfig {
 
 // Internal parameters
 export function getJobMatrix(): string {
-    return core.getInput('workflow-job-context')
+    return state.getInput('workflow-job-context')
 }
 
 export function getGithubToken(): string {
-    return core.getInput('github-token', {required: true})
+    return state.getInput('github-token', {required: true})
 }
 
 export function getWorkspaceDirectory(): string {
@@ -387,7 +388,7 @@ export function getActionId(): string | undefined {
 }
 
 export function setActionId(id: string): void {
-    core.exportVariable(ACTION_ID_VAR, id)
+    state.exportVariable(ACTION_ID_VAR, id)
 }
 
 export function parseNumericInput(paramName: string, paramValue: string, paramDefault: number): number {
@@ -402,7 +403,7 @@ export function parseNumericInput(paramName: string, paramValue: string, paramDe
 }
 
 function getOptionalInput(paramName: string): string | undefined {
-    const paramValue = core.getInput(paramName)
+    const paramValue = state.getInput(paramName)
     if (paramValue.length > 0) {
         return paramValue
     }
@@ -410,7 +411,7 @@ function getOptionalInput(paramName: string): string | undefined {
 }
 
 function getBooleanInput(paramName: string, paramDefault = false): boolean {
-    const paramValue = core.getInput(paramName)
+    const paramValue = state.getInput(paramName)
     switch (paramValue.toLowerCase().trim()) {
         case '':
             return paramDefault
@@ -423,7 +424,7 @@ function getBooleanInput(paramName: string, paramDefault = false): boolean {
 }
 
 function getOptionalBooleanInput(paramName: string): boolean | undefined {
-    const paramValue = core.getInput(paramName)
+    const paramValue = state.getInput(paramName)
     if (paramValue === '') {
         return undefined
     }

--- a/sources/src/dependency-graph.ts
+++ b/sources/src/dependency-graph.ts
@@ -47,7 +47,7 @@ export async function setup(config: DependencyGraphConfig): Promise<void> {
 function maybeExportVariable(variableName: string, value: string | boolean | undefined): void {
     if (!process.env[variableName]) {
         if (value !== undefined) {
-            state.exportVariable(variableName, JSON.stringify(value))
+            state.exportVariable(variableName, value)
         }
     }
 }

--- a/sources/src/dependency-graph.ts
+++ b/sources/src/dependency-graph.ts
@@ -11,7 +11,7 @@ import fs from 'fs'
 
 import {JobFailure} from './errors'
 import {DependencyGraphConfig, DependencyGraphOption, getGithubToken, getWorkspaceDirectory} from './configuration'
-import {state} from './env/state'
+import {state} from './env'
 
 const DEPENDENCY_GRAPH_PREFIX = 'dependency-graph_'
 

--- a/sources/src/dependency-graph.ts
+++ b/sources/src/dependency-graph.ts
@@ -11,13 +11,14 @@ import fs from 'fs'
 
 import {JobFailure} from './errors'
 import {DependencyGraphConfig, DependencyGraphOption, getGithubToken, getWorkspaceDirectory} from './configuration'
+import {state} from './env/state'
 
 const DEPENDENCY_GRAPH_PREFIX = 'dependency-graph_'
 
 export async function setup(config: DependencyGraphConfig): Promise<void> {
     const option = config.getDependencyGraphOption()
     if (option === DependencyGraphOption.Disabled) {
-        core.exportVariable('GITHUB_DEPENDENCY_GRAPH_ENABLED', 'false')
+        state.exportVariable('GITHUB_DEPENDENCY_GRAPH_ENABLED', 'false')
         return
     }
     // Download and submit early, for compatability with dependency review.
@@ -28,7 +29,7 @@ export async function setup(config: DependencyGraphConfig): Promise<void> {
     }
 
     core.info('Enabling dependency graph generation')
-    core.exportVariable('GITHUB_DEPENDENCY_GRAPH_ENABLED', 'true')
+    state.exportVariable('GITHUB_DEPENDENCY_GRAPH_ENABLED', 'true')
     maybeExportVariable('GITHUB_DEPENDENCY_GRAPH_CONTINUE_ON_FAILURE', config.getDependencyGraphContinueOnFailure())
     maybeExportVariable('GITHUB_DEPENDENCY_GRAPH_JOB_CORRELATOR', config.getJobCorrelator())
     maybeExportVariable('GITHUB_DEPENDENCY_GRAPH_JOB_ID', github.context.runId.toString())
@@ -46,7 +47,7 @@ export async function setup(config: DependencyGraphConfig): Promise<void> {
 function maybeExportVariable(variableName: string, value: string | boolean | undefined): void {
     if (!process.env[variableName]) {
         if (value !== undefined) {
-            core.exportVariable(variableName, value)
+            state.exportVariable(variableName, JSON.stringify(value))
         }
     }
 }

--- a/sources/src/deprecation-collector.ts
+++ b/sources/src/deprecation-collector.ts
@@ -1,5 +1,6 @@
 import * as core from '@actions/core'
 import {getActionId} from './configuration'
+import {state} from './env/state'
 
 const DEPRECATION_UPGRADE_PAGE = 'https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md'
 const recordedDeprecations: Deprecation[] = []
@@ -27,7 +28,7 @@ export function failOnUseOfRemovedFeature(removalMessage: string, deprecationMes
     const deprecation = new Deprecation(deprecationMessage)
     const errorMessage = `${removalMessage}.\nSee ${deprecation.getDocumentationLink()}`
     recordedErrors.push(errorMessage)
-    core.setFailed(errorMessage)
+    state.setFailed(errorMessage)
 }
 
 export function getDeprecations(): Deprecation[] {
@@ -50,12 +51,12 @@ export function emitDeprecationWarnings(hasJobSummary = true): void {
 }
 
 export function saveDeprecationState(): void {
-    core.saveState('deprecation-collector_deprecations', JSON.stringify(recordedDeprecations))
-    core.saveState('deprecation-collector_errors', JSON.stringify(recordedErrors))
+    state.save('deprecation-collector_deprecations', JSON.stringify(recordedDeprecations))
+    state.save('deprecation-collector_errors', JSON.stringify(recordedErrors))
 }
 
 export function restoreDeprecationState(): void {
-    const savedDeprecations = core.getState('deprecation-collector_deprecations')
+    const savedDeprecations = state.get('deprecation-collector_deprecations')
     if (savedDeprecations) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         JSON.parse(savedDeprecations).forEach((obj: any) => {
@@ -63,7 +64,7 @@ export function restoreDeprecationState(): void {
         })
     }
 
-    const savedErrors = core.getState('deprecation-collector_errors')
+    const savedErrors = state.get('deprecation-collector_errors')
     if (savedErrors) {
         recordedErrors.push(...JSON.parse(savedErrors))
     }

--- a/sources/src/deprecation-collector.ts
+++ b/sources/src/deprecation-collector.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
 import {getActionId} from './configuration'
-import {state} from './env/state'
+import {state} from './env'
 
 const DEPRECATION_UPGRADE_PAGE = 'https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md'
 const recordedDeprecations: Deprecation[] = []

--- a/sources/src/develocity/build-scan.ts
+++ b/sources/src/develocity/build-scan.ts
@@ -33,7 +33,7 @@ export async function setup(config: BuildScanConfig): Promise<void> {
 
 function maybeExportVariable(variableName: string, value: unknown): void {
     if (!process.env[variableName]) {
-        state.exportVariable(variableName, JSON.stringify(value))
+        state.exportVariable(variableName, value)
     }
 }
 

--- a/sources/src/develocity/build-scan.ts
+++ b/sources/src/develocity/build-scan.ts
@@ -1,6 +1,6 @@
 import {BuildScanConfig} from '../configuration'
 import {setupToken} from './short-lived-token'
-import {state} from '../env/state'
+import {state} from '../env'
 
 export async function setup(config: BuildScanConfig): Promise<void> {
     maybeExportVariable('DEVELOCITY_INJECTION_INIT_SCRIPT_NAME', 'gradle-actions.inject-develocity.init.gradle')

--- a/sources/src/develocity/build-scan.ts
+++ b/sources/src/develocity/build-scan.ts
@@ -1,6 +1,6 @@
-import * as core from '@actions/core'
 import {BuildScanConfig} from '../configuration'
 import {setupToken} from './short-lived-token'
+import {state} from '../env/state'
 
 export async function setup(config: BuildScanConfig): Promise<void> {
     maybeExportVariable('DEVELOCITY_INJECTION_INIT_SCRIPT_NAME', 'gradle-actions.inject-develocity.init.gradle')
@@ -33,7 +33,7 @@ export async function setup(config: BuildScanConfig): Promise<void> {
 
 function maybeExportVariable(variableName: string, value: unknown): void {
     if (!process.env[variableName]) {
-        core.exportVariable(variableName, value)
+        state.exportVariable(variableName, JSON.stringify(value))
     }
 }
 

--- a/sources/src/develocity/short-lived-token.ts
+++ b/sources/src/develocity/short-lived-token.ts
@@ -2,7 +2,7 @@ import * as httpm from 'typed-rest-client/HttpClient'
 import * as core from '@actions/core'
 import {BuildScanConfig} from '../configuration'
 import {recordDeprecation} from '../deprecation-collector'
-import {state} from '../env/state'
+import {state} from '../env'
 
 export async function setupToken(develocityAccessKey: string, develocityTokenExpiry: string): Promise<void> {
     if (develocityAccessKey) {

--- a/sources/src/develocity/short-lived-token.ts
+++ b/sources/src/develocity/short-lived-token.ts
@@ -2,6 +2,7 @@ import * as httpm from 'typed-rest-client/HttpClient'
 import * as core from '@actions/core'
 import {BuildScanConfig} from '../configuration'
 import {recordDeprecation} from '../deprecation-collector'
+import {state} from '../env/state'
 
 export async function setupToken(develocityAccessKey: string, develocityTokenExpiry: string): Promise<void> {
     if (develocityAccessKey) {
@@ -25,7 +26,7 @@ export async function setupToken(develocityAccessKey: string, develocityTokenExp
 
 function exportAccessKeyEnvVars(value: string): void {
     ;[BuildScanConfig.DevelocityAccessKeyEnvVar, BuildScanConfig.GradleEnterpriseAccessKeyEnvVar].forEach(key =>
-        core.exportVariable(key, value)
+        state.exportVariable(key, value)
     )
 }
 

--- a/sources/src/errors.ts
+++ b/sources/src/errors.ts
@@ -1,4 +1,5 @@
 import * as core from '@actions/core'
+import {state} from './env/state'
 
 export class JobFailure extends Error {
     constructor(error: unknown) {
@@ -14,7 +15,7 @@ export class JobFailure extends Error {
 
 export function handleMainActionError(error: unknown): void {
     if (error instanceof AggregateError) {
-        core.setFailed(`Multiple errors returned`)
+        state.setFailed(`Multiple errors returned`)
         for (const err of error.errors) {
             core.error(`Error ${error.errors.indexOf(err)}: ${err.message}`)
             if (err.stack) {
@@ -22,12 +23,12 @@ export function handleMainActionError(error: unknown): void {
             }
         }
     } else if (error instanceof JobFailure) {
-        core.setFailed(String(error))
+        state.setFailed(String(error))
         if (error.stack) {
             core.info(error.stack)
         }
     } else {
-        core.setFailed(String(error))
+        state.setFailed(String(error))
         if (error instanceof Error && error.stack) {
             core.info(error.stack)
         }
@@ -36,7 +37,7 @@ export function handleMainActionError(error: unknown): void {
 
 export function handlePostActionError(error: unknown): void {
     if (error instanceof JobFailure) {
-        core.setFailed(String(error))
+        state.setFailed(String(error))
         if (error.stack) {
             core.info(error.stack)
         }

--- a/sources/src/errors.ts
+++ b/sources/src/errors.ts
@@ -1,5 +1,5 @@
 import * as core from '@actions/core'
-import {state} from './env/state'
+import {state} from './env'
 
 export class JobFailure extends Error {
     constructor(error: unknown) {

--- a/sources/src/execution/gradle.ts
+++ b/sources/src/execution/gradle.ts
@@ -4,7 +4,7 @@ import which from 'which'
 import * as semver from 'semver'
 import * as provisioner from './provision'
 import * as gradlew from './gradlew'
-import {state} from '../env/state'
+import {state} from '../env'
 
 export async function provisionAndMaybeExecute(
     gradleVersion: string,

--- a/sources/src/execution/gradle.ts
+++ b/sources/src/execution/gradle.ts
@@ -1,10 +1,10 @@
-import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 
 import which from 'which'
 import * as semver from 'semver'
 import * as provisioner from './provision'
 import * as gradlew from './gradlew'
+import {state} from '../env/state'
 
 export async function provisionAndMaybeExecute(
     gradleVersion: string,
@@ -30,7 +30,7 @@ async function executeGradleBuild(executable: string | undefined, root: string, 
     })
 
     if (status !== 0) {
-        core.setFailed(`Gradle build failed: see console output for details`)
+        state.setFailed(`Gradle build failed: see console output for details`)
     }
 }
 

--- a/sources/src/setup-gradle.ts
+++ b/sources/src/setup-gradle.ts
@@ -39,9 +39,9 @@ export async function setup(
         return false
     }
     // Record setup complete: visible to all subsequent actions and prevents duplicate setup
-    state.exportVariable(GRADLE_SETUP_VAR, true.toString())
+    state.exportVariable(GRADLE_SETUP_VAR, true)
     // Record setup complete: visible in post-action, to control action completion
-    state.save(GRADLE_SETUP_VAR, true.toString())
+    state.save(GRADLE_SETUP_VAR, true)
 
     // Save the User Home and Gradle User Home for use in the post-action step.
     state.save(USER_HOME, userHome)

--- a/sources/src/setup-gradle.ts
+++ b/sources/src/setup-gradle.ts
@@ -18,7 +18,7 @@ import {
     getWorkspaceDirectory
 } from './configuration'
 import * as wrapperValidator from './wrapper-validation/wrapper-validator'
-import {state} from './env/state'
+import {state} from './env'
 
 const GRADLE_SETUP_VAR = 'GRADLE_BUILD_ACTION_SETUP_COMPLETED'
 const USER_HOME = 'USER_HOME'

--- a/sources/src/setup-gradle.ts
+++ b/sources/src/setup-gradle.ts
@@ -18,6 +18,7 @@ import {
     getWorkspaceDirectory
 } from './configuration'
 import * as wrapperValidator from './wrapper-validation/wrapper-validator'
+import {state} from './env/state'
 
 const GRADLE_SETUP_VAR = 'GRADLE_BUILD_ACTION_SETUP_COMPLETED'
 const USER_HOME = 'USER_HOME'
@@ -38,18 +39,18 @@ export async function setup(
         return false
     }
     // Record setup complete: visible to all subsequent actions and prevents duplicate setup
-    core.exportVariable(GRADLE_SETUP_VAR, true)
+    state.exportVariable(GRADLE_SETUP_VAR, true.toString())
     // Record setup complete: visible in post-action, to control action completion
-    core.saveState(GRADLE_SETUP_VAR, true)
+    state.save(GRADLE_SETUP_VAR, true.toString())
 
     // Save the User Home and Gradle User Home for use in the post-action step.
-    core.saveState(USER_HOME, userHome)
-    core.saveState(GRADLE_USER_HOME, gradleUserHome)
+    state.save(USER_HOME, userHome)
+    state.save(GRADLE_USER_HOME, gradleUserHome)
 
     const cacheListener = new CacheListener()
     await caches.restore(userHome, gradleUserHome, cacheListener, cacheConfig)
 
-    core.saveState(CACHE_LISTENER, cacheListener.stringify())
+    state.save(CACHE_LISTENER, cacheListener.stringify())
 
     await wrapperValidator.validateWrappers(wrapperValidationConfig, getWorkspaceDirectory(), gradleUserHome)
 
@@ -59,7 +60,7 @@ export async function setup(
 }
 
 export async function complete(cacheConfig: CacheConfig, summaryConfig: SummaryConfig): Promise<boolean> {
-    if (!core.getState(GRADLE_SETUP_VAR)) {
+    if (!state.get(GRADLE_SETUP_VAR)) {
         core.info('Gradle setup post-action only performed for first gradle/actions step in workflow.')
         return false
     }
@@ -67,9 +68,9 @@ export async function complete(cacheConfig: CacheConfig, summaryConfig: SummaryC
 
     const buildResults = loadBuildResults()
 
-    const userHome = core.getState(USER_HOME)
-    const gradleUserHome = core.getState(GRADLE_USER_HOME)
-    const cacheListener: CacheListener = CacheListener.rehydrate(core.getState(CACHE_LISTENER))
+    const userHome = state.get(USER_HOME)
+    const gradleUserHome = state.get(GRADLE_USER_HOME)
+    const cacheListener: CacheListener = CacheListener.rehydrate(state.get(CACHE_LISTENER))
 
     const daemonController = new DaemonController(buildResults)
     await caches.save(userHome, gradleUserHome, cacheListener, daemonController, buildResults, cacheConfig)
@@ -95,7 +96,7 @@ async function determineGradleUserHome(): Promise<string> {
     // Use the default Gradle User Home if it already exists
     if (fs.existsSync(defaultGradleUserHome)) {
         core.info(`Gradle User Home already exists at ${defaultGradleUserHome}`)
-        core.exportVariable('GRADLE_USER_HOME', defaultGradleUserHome)
+        state.exportVariable('GRADLE_USER_HOME', defaultGradleUserHome)
         return defaultGradleUserHome
     }
 
@@ -103,11 +104,11 @@ async function determineGradleUserHome(): Promise<string> {
     if (os.platform() === 'win32' && defaultGradleUserHome.startsWith('C:\\') && fs.existsSync('D:\\a\\')) {
         const fasterGradleUserHome = 'D:\\a\\.gradle'
         core.info(`Setting GRADLE_USER_HOME to ${fasterGradleUserHome} to leverage (potentially) faster drive.`)
-        core.exportVariable('GRADLE_USER_HOME', fasterGradleUserHome)
+        state.exportVariable('GRADLE_USER_HOME', fasterGradleUserHome)
         return fasterGradleUserHome
     }
 
-    core.exportVariable('GRADLE_USER_HOME', defaultGradleUserHome)
+    state.exportVariable('GRADLE_USER_HOME', defaultGradleUserHome)
     return defaultGradleUserHome
 }
 


### PR DESCRIPTION
Following #18, we finish replacing all usages. This was split to enable easier
review and acknowledge there's a couple small behaviour changes using `true.toString()` for example.

Part of gradle/actions#502.