### PR TITLE
MultiCI: Abstract Logging behind new type

### DIFF
--- a/sources/src/actions/github-actions-env.ts
+++ b/sources/src/actions/github-actions-env.ts
@@ -1,5 +1,5 @@
 import * as core from '@actions/core'
-import {state} from '../env'
+import {log, LogLevel, state} from '../env'
 
 function setupState(): void {
     state.setImpl({
@@ -13,6 +13,30 @@ function setupState(): void {
     })
 }
 
+function setupLogger(): void {
+    // Redirect the log output to the GitHub Actions logging system.
+    log.setWriter((level, message) => {
+        switch (level) {
+            case LogLevel.DEBUG:
+                core.debug(message)
+                break
+            case LogLevel.INFO:
+                core.info(message)
+                break
+            case LogLevel.NOTICE:
+                core.notice(message)
+                break
+            case LogLevel.WARN:
+                core.warning(message)
+                break
+            case LogLevel.ERROR:
+                core.error(message)
+                break
+        }
+    })
+}
+
 export const configureGithubEnv = (): void => {
     setupState()
+    setupLogger()
 }

--- a/sources/src/caching/cache-cleaner.ts
+++ b/sources/src/caching/cache-cleaner.ts
@@ -4,7 +4,7 @@ import * as exec from '@actions/exec'
 import fs from 'fs'
 import path from 'path'
 import * as provisioner from '../execution/provision'
-import {state} from '../env'
+import {log, state} from '../env'
 
 export class CacheCleaner {
     private readonly gradleUserHome: string
@@ -60,7 +60,7 @@ export class CacheCleaner {
         const executable = await provisioner.provisionGradleAtLeast('8.12')
 
         await core.group('Executing Gradle to clean up caches', async () => {
-            core.info(`Cleaning up caches last used before ${cleanTimestamp}`)
+            log.info(`Cleaning up caches last used before ${cleanTimestamp}`)
             await this.executeCleanupBuild(executable, cleanupProjectDir)
         })
     }

--- a/sources/src/caching/cache-utils.ts
+++ b/sources/src/caching/cache-utils.ts
@@ -1,4 +1,3 @@
-import * as core from '@actions/core'
 import * as cache from '@actions/cache'
 import * as exec from '@actions/exec'
 
@@ -6,18 +5,11 @@ import * as crypto from 'crypto'
 import * as path from 'path'
 import * as fs from 'fs'
 
-import {state} from '../env'
+import {log} from '../env'
 import {CacheEntryListener} from './cache-reporting'
 
 const SEGMENT_DOWNLOAD_TIMEOUT_VAR = 'SEGMENT_DOWNLOAD_TIMEOUT_MINS'
 const SEGMENT_DOWNLOAD_TIMEOUT_DEFAULT = 10 * 60 * 1000 // 10 minutes
-
-export function isCacheDebuggingEnabled(): boolean {
-    if (state.isDebug()) {
-        return true
-    }
-    return process.env['GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED'] ? true : false
-}
 
 export function hashFileNames(fileNames: string[]): string {
     return hashStrings(fileNames.map(x => x.replace(new RegExp(`\\${path.sep}`, 'g'), '/')))
@@ -48,7 +40,7 @@ export async function restoreCache(
         if (restoredEntry !== undefined) {
             const restoreTime = Date.now() - startTime
             listener.markRestored(restoredEntry.key, restoredEntry.size, restoreTime)
-            core.info(`Restored cache entry with key ${cacheKey} to ${cachePath.join()} in ${restoreTime}ms`)
+            log.info(`Restored cache entry with key ${cacheKey} to ${cachePath.join()} in ${restoreTime}ms`)
         }
         return restoredEntry
     } catch (error) {
@@ -64,7 +56,7 @@ export async function saveCache(cachePath: string[], cacheKey: string, listener:
         const savedEntry = await cache.saveCache(cachePath, cacheKey)
         const saveTime = Date.now() - startTime
         listener.markSaved(savedEntry.key, savedEntry.size, saveTime)
-        core.info(`Saved cache entry with key ${cacheKey} from ${cachePath.join()} in ${saveTime}ms`)
+        log.info(`Saved cache entry with key ${cacheKey} from ${cachePath.join()} in ${saveTime}ms`)
     } catch (error) {
         if (error instanceof cache.ReserveCacheError) {
             listener.markAlreadyExists(cacheKey)
@@ -75,14 +67,6 @@ export async function saveCache(cachePath: string[], cacheKey: string, listener:
     }
 }
 
-export function cacheDebug(message: string): void {
-    if (isCacheDebuggingEnabled()) {
-        core.info(message)
-    } else {
-        core.debug(message)
-    }
-}
-
 export function handleCacheFailure(error: unknown, message: string): void {
     if (error instanceof cache.ValidationError) {
         // Fail on cache validation errors
@@ -90,12 +74,12 @@ export function handleCacheFailure(error: unknown, message: string): void {
     }
     if (error instanceof cache.ReserveCacheError) {
         // Reserve cache errors are expected if the artifact has been previously cached
-        core.info(`${message}: ${error}`)
+        log.info(`${message}: ${error}`)
     } else {
         // Warn on all other errors
-        core.warning(`${message}: ${error}`)
+        log.warn(`${message}: ${error}`)
         if (error instanceof Error && error.stack) {
-            cacheDebug(error.stack)
+            log.cacheDebug(error.stack)
         }
     }
 }
@@ -119,12 +103,12 @@ export async function tryDelete(file: string): Promise<void> {
             return
         } catch (error) {
             if (attempt === maxAttempts) {
-                core.warning(`Failed to delete ${file}, which will impact caching. 
+                log.warn(`Failed to delete ${file}, which will impact caching. 
 It is likely locked by another process. Output of 'jps -ml':
 ${await getJavaProcesses()}`)
                 throw error
             } else {
-                cacheDebug(`Attempt to delete ${file} failed. Will try again.`)
+                log.cacheDebug(`Attempt to delete ${file} failed. Will try again.`)
                 await delay(1000)
             }
         }

--- a/sources/src/caching/gradle-home-extry-extractor.ts
+++ b/sources/src/caching/gradle-home-extry-extractor.ts
@@ -1,11 +1,11 @@
 import path from 'path'
 import fs from 'fs'
-import * as core from '@actions/core'
 import * as glob from '@actions/glob'
 
 import {CacheEntryListener, CacheListener} from './cache-reporting'
-import {cacheDebug, hashFileNames, isCacheDebuggingEnabled, restoreCache, saveCache, tryDelete} from './cache-utils'
+import {hashFileNames, restoreCache, saveCache, tryDelete} from './cache-utils'
 
+import {log, state} from '../env'
 import {BuildResult, loadBuildResults} from '../build-results'
 import {CacheConfig, ACTION_METADATA_DIR} from '../configuration'
 import {getCacheKeyBase} from './cache-key'
@@ -107,7 +107,7 @@ abstract class AbstractEntryExtractor {
             // Handle case where the extracted-cache-entry definitions have been changed
             const skipRestore = process.env[SKIP_RESTORE_VAR] || ''
             if (skipRestore.includes(artifactType)) {
-                core.info(`Not restoring extracted cache entry for ${artifactType}`)
+                log.info(`Not restoring extracted cache entry for ${artifactType}`)
                 entryListener.markRequested('SKIP_RESTORE')
             } else {
                 processes.push(
@@ -136,7 +136,7 @@ abstract class AbstractEntryExtractor {
         if (restoredEntry) {
             return new ExtractedCacheEntry(artifactType, pattern, cacheKey)
         } else {
-            core.info(`Did not restore ${artifactType} with key ${cacheKey} to ${pattern}`)
+            log.info(`Did not restore ${artifactType} with key ${cacheKey} to ${pattern}`)
             return new ExtractedCacheEntry(artifactType, pattern, undefined)
         }
     }
@@ -148,7 +148,7 @@ abstract class AbstractEntryExtractor {
     async extract(listener: CacheListener): Promise<void> {
         // Load the cache entry definitions (from config) and the previously restored entries (from persisted metadata file)
         const cacheEntryDefinitions = this.getExtractedCacheEntryDefinitions()
-        cacheDebug(
+        log.cacheDebug(
             `Extracting cache entries for ${this.extractorName}: ${JSON.stringify(cacheEntryDefinitions, null, 2)}`
         )
 
@@ -172,7 +172,7 @@ abstract class AbstractEntryExtractor {
             const matchingFiles = await globber.glob()
 
             if (matchingFiles.length === 0) {
-                cacheDebug(`No files found to cache for ${artifactType}`)
+                log.cacheDebug(`No files found to cache for ${artifactType}`)
                 continue
             }
 
@@ -228,7 +228,7 @@ abstract class AbstractEntryExtractor {
         )?.cacheKey
 
         if (previouslyRestoredKey === cacheKey) {
-            cacheDebug(`No change to previously restored ${artifactType}. Not saving.`)
+            log.cacheDebug(`No change to previously restored ${artifactType}. Not saving.`)
             entryListener.markNotSaved('contents unchanged')
         } else {
             await saveCache(pattern.split('\n'), cacheKey, entryListener)
@@ -245,7 +245,7 @@ abstract class AbstractEntryExtractor {
         const relativeFiles = files.map(x => path.relative(this.gradleUserHome, x))
         const key = hashFileNames(relativeFiles)
 
-        cacheDebug(`Generating cache key for ${artifactType} from file names: ${relativeFiles}`)
+        log.cacheDebug(`Generating cache key for ${artifactType} from file names: ${relativeFiles}`)
 
         return `${getCacheKeyBase(artifactType, CACHE_PROTOCOL_VERSION)}-${key}`
     }
@@ -253,14 +253,14 @@ abstract class AbstractEntryExtractor {
     protected async createCacheKeyFromFileContents(artifactType: string, pattern: string): Promise<string> {
         const key = await glob.hashFiles(pattern)
 
-        cacheDebug(`Generating cache key for ${artifactType} from files matching: ${pattern}`)
+        log.cacheDebug(`Generating cache key for ${artifactType} from files matching: ${pattern}`)
 
         return `${getCacheKeyBase(artifactType, CACHE_PROTOCOL_VERSION)}-${key}`
     }
 
     // Run actions sequentially if debugging is enabled
     private async awaitForDebugging(p: Promise<ExtractedCacheEntry>): Promise<ExtractedCacheEntry> {
-        if (isCacheDebuggingEnabled()) {
+        if (state.isCacheDebuggingEnabled()) {
             await p
         }
         return p
@@ -276,7 +276,7 @@ abstract class AbstractEntryExtractor {
         }
 
         const filedata = fs.readFileSync(cacheMetadataFile, 'utf-8')
-        cacheDebug(`Loaded cache metadata for ${this.extractorName}: ${filedata}`)
+        log.cacheDebug(`Loaded cache metadata for ${this.extractorName}: ${filedata}`)
         const extractedCacheEntryMetadata = JSON.parse(filedata) as ExtractedCacheEntryMetadata
         return extractedCacheEntryMetadata.entries
     }
@@ -289,7 +289,7 @@ abstract class AbstractEntryExtractor {
         extractedCacheEntryMetadata.entries = results.filter(x => x.cacheKey !== undefined)
 
         const filedata = JSON.stringify(extractedCacheEntryMetadata)
-        cacheDebug(`Saving cache metadata for ${this.extractorName}: ${filedata}`)
+        log.cacheDebug(`Saving cache metadata for ${this.extractorName}: ${filedata}`)
 
         fs.writeFileSync(this.getCacheMetadataFile(), filedata, 'utf-8')
     }
@@ -325,7 +325,7 @@ export class GradleHomeEntryExtractor extends AbstractEntryExtractor {
         })
 
         for (const wrapperZip of await globber.glob()) {
-            cacheDebug(`Deleting wrapper zip: ${wrapperZip}`)
+            log.cacheDebug(`Deleting wrapper zip: ${wrapperZip}`)
             await tryDelete(wrapperZip)
         }
     }
@@ -389,7 +389,7 @@ export class ConfigurationCacheEntryExtractor extends AbstractEntryExtractor {
     private markNotRestored(listener: CacheListener, reason: string): void {
         const cacheEntries = this.loadExtractedCacheEntries()
         if (cacheEntries.length > 0) {
-            core.info(`Not restoring configuration-cache state, as ${reason}`)
+            log.info(`Not restoring configuration-cache state, as ${reason}`)
             for (const cacheEntry of cacheEntries) {
                 listener.entry(cacheEntry.pattern).markNotRestored(reason)
             }
@@ -403,7 +403,7 @@ export class ConfigurationCacheEntryExtractor extends AbstractEntryExtractor {
         if (!this.cacheConfig.getCacheEncryptionKey()) {
             const cacheEntryDefinitions = this.getExtractedCacheEntryDefinitions()
             if (cacheEntryDefinitions.length > 0) {
-                core.info('Not saving configuration-cache state, as no encryption key was provided')
+                log.info('Not saving configuration-cache state, as no encryption key was provided')
                 for (const cacheEntry of cacheEntryDefinitions) {
                     listener.entry(cacheEntry.pattern).markNotSaved('No encryption key provided')
                 }
@@ -435,7 +435,7 @@ export class ConfigurationCacheEntryExtractor extends AbstractEntryExtractor {
                     return !versionIsAtLeast(result.gradleVersion, '8.6.0')
                 })
             ) {
-                core.info(
+                log.info(
                     `Not saving config-cache data for ${configCachePath}. Configuration cache data is only saved for Gradle 8.6+`
                 )
                 definition.notCacheableBecause('Configuration cache data only saved for Gradle 8.6+')

--- a/sources/src/caching/gradle-user-home-cache.ts
+++ b/sources/src/caching/gradle-user-home-cache.ts
@@ -1,4 +1,3 @@
-import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import * as glob from '@actions/glob'
 
@@ -6,11 +5,11 @@ import path from 'path'
 import fs from 'fs'
 import {generateCacheKey} from './cache-key'
 import {CacheListener} from './cache-reporting'
-import {saveCache, restoreCache, cacheDebug, isCacheDebuggingEnabled, tryDelete} from './cache-utils'
+import {saveCache, restoreCache, tryDelete} from './cache-utils'
 import {CacheConfig, ACTION_METADATA_DIR} from '../configuration'
 import {GradleHomeEntryExtractor, ConfigurationCacheEntryExtractor} from './gradle-home-extry-extractor'
 import {getPredefinedToolchains, mergeToolchainContent, readResourceFileAsString} from './gradle-user-home-utils'
-import {state} from '../env'
+import {log, state} from '../env'
 
 const RESTORED_CACHE_KEY_KEY = 'restored-cache-key'
 
@@ -41,7 +40,7 @@ export class GradleUserHomeCache {
     cacheOutputExists(): boolean {
         const cachesDir = path.resolve(this.gradleUserHome, 'caches')
         if (fs.existsSync(cachesDir)) {
-            cacheDebug(`Cache output exists at ${cachesDir}`)
+            log.cacheDebug(`Cache output exists at ${cachesDir}`)
             return true
         }
         return false
@@ -55,7 +54,7 @@ export class GradleUserHomeCache {
 
         const cacheKey = generateCacheKey(this.cacheName, this.cacheConfig)
 
-        cacheDebug(
+        log.cacheDebug(
             `Requesting ${this.cacheDescription} with
     key:${cacheKey.key}
     restoreKeys:[${cacheKey.restoreKeys}]`
@@ -64,7 +63,7 @@ export class GradleUserHomeCache {
         const cachePath = this.getCachePath()
         const cacheResult = await restoreCache(cachePath, cacheKey.key, cacheKey.restoreKeys, entryListener)
         if (!cacheResult) {
-            core.info(`${this.cacheDescription} cache not found. Will initialize empty.`)
+            log.info(`${this.cacheDescription} cache not found. Will initialize empty.`)
             return
         }
 
@@ -73,7 +72,7 @@ export class GradleUserHomeCache {
         try {
             await this.afterRestore(listener)
         } catch (error) {
-            core.warning(`Restore ${this.cacheDescription} failed in 'afterRestore': ${error}`)
+            log.warn(`Restore ${this.cacheDescription} failed in 'afterRestore': ${error}`)
         }
     }
 
@@ -101,7 +100,7 @@ export class GradleUserHomeCache {
         const gradleHomeEntryListener = listener.entry(this.cacheDescription)
 
         if (restoredCacheKey && cacheKey === restoredCacheKey) {
-            core.info(`Cache hit occurred on the cache key ${cacheKey}, not saving cache.`)
+            log.info(`Cache hit occurred on the cache key ${cacheKey}, not saving cache.`)
 
             for (const entryListener of listener.cacheEntries) {
                 if (entryListener === gradleHomeEntryListener) {
@@ -116,7 +115,7 @@ export class GradleUserHomeCache {
         try {
             await this.beforeSave(listener)
         } catch (error) {
-            core.warning(`Save ${this.cacheDescription} failed in 'beforeSave': ${error}`)
+            log.warn(`Save ${this.cacheDescription} failed in 'beforeSave': ${error}`)
             return
         }
 
@@ -149,13 +148,13 @@ export class GradleUserHomeCache {
         const resolvedPaths = rawPaths.map(x => path.resolve(this.gradleUserHome, x))
 
         for (const p of resolvedPaths) {
-            cacheDebug(`Removing excluded path: ${p}`)
+            log.cacheDebug(`Removing excluded path: ${p}`)
             const globber = await glob.create(p, {
                 implicitDescendants: false
             })
 
             for (const toDelete of await globber.glob()) {
-                cacheDebug(`Removing excluded file: ${toDelete}`)
+                log.cacheDebug(`Removing excluded file: ${toDelete}`)
                 await tryDelete(toDelete)
             }
         }
@@ -170,7 +169,7 @@ export class GradleUserHomeCache {
         const rawPaths: string[] = this.cacheConfig.getCacheIncludes()
         rawPaths.push(ACTION_METADATA_DIR)
         const resolvedPaths = rawPaths.map(x => this.resolveCachePath(x))
-        cacheDebug(`Using cache paths: ${resolvedPaths}`)
+        log.cacheDebug(`Using cache paths: ${resolvedPaths}`)
         return resolvedPaths
     }
 
@@ -226,14 +225,14 @@ export class GradleUserHomeCache {
             fs.mkdirSync(m2dir, {recursive: true})
             fs.writeFileSync(toolchainXmlTarget, preInstalledToolchains)
 
-            core.info(`Wrote default JDK locations to ${toolchainXmlTarget}`)
+            log.info(`Wrote default JDK locations to ${toolchainXmlTarget}`)
         } else {
             // Merge into an existing toolchains.xml file
             const existingToolchainContent = fs.readFileSync(toolchainXmlTarget, 'utf8')
             const mergedContent = mergeToolchainContent(existingToolchainContent, preInstalledToolchains)
 
             fs.writeFileSync(toolchainXmlTarget, mergedContent)
-            core.info(`Merged default JDK locations into ${toolchainXmlTarget}`)
+            log.info(`Merged default JDK locations into ${toolchainXmlTarget}`)
         }
     }
 
@@ -247,11 +246,11 @@ export class GradleUserHomeCache {
         const infoProperties = `org.gradle.logging.level=info\norg.gradle.logging.stacktrace=all\n`
         const propertiesFile = path.resolve(this.gradleUserHome, 'gradle.properties')
         if (fs.existsSync(propertiesFile)) {
-            core.info(`Merged --info and --stacktrace into existing ${propertiesFile} file`)
+            log.info(`Merged --info and --stacktrace into existing ${propertiesFile} file`)
             const existingProperties = fs.readFileSync(propertiesFile, 'utf-8')
             fs.writeFileSync(propertiesFile, `${infoProperties}\n${existingProperties}`)
         } else {
-            core.info(`Created a new ${propertiesFile} with --info and --stacktrace`)
+            log.info(`Created a new ${propertiesFile} with --info and --stacktrace`)
             fs.writeFileSync(propertiesFile, infoProperties)
         }
     }
@@ -261,7 +260,7 @@ export class GradleUserHomeCache {
      * this method will give a detailed report of the Gradle User Home contents.
      */
     private async debugReportGradleUserHomeSize(label: string): Promise<void> {
-        if (!isCacheDebuggingEnabled() && !state.isDebug()) {
+        if (!state.isCacheDebuggingEnabled() && !state.isDebug()) {
             return
         }
         if (!fs.existsSync(this.gradleUserHome)) {
@@ -273,9 +272,9 @@ export class GradleUserHomeCache {
             ignoreReturnCode: true
         })
 
-        core.info(`Gradle User Home (directories >5M): ${label}`)
+        log.info(`Gradle User Home (directories >5M): ${label}`)
 
-        core.info(
+        log.info(
             result.stdout
                 .trimEnd()
                 .replace(/\t/g, '    ')
@@ -286,6 +285,6 @@ export class GradleUserHomeCache {
                 .join('\n')
         )
 
-        core.info('-----------------------')
+        log.info('-----------------------')
     }
 }

--- a/sources/src/env/index.ts
+++ b/sources/src/env/index.ts
@@ -1,4 +1,8 @@
+import {Logger} from './logging'
 import {CIState} from './state'
 
 export {CIStateInputOptions} from './state'
 export const state = new CIState()
+
+export {LogLevel} from './logging'
+export const log = new Logger()

--- a/sources/src/env/logging.ts
+++ b/sources/src/env/logging.ts
@@ -1,0 +1,59 @@
+import {state} from '.'
+
+/**
+ * Provides simple access to log levels.
+ */
+export enum LogLevel {
+    DEBUG,
+    INFO,
+    NOTICE,
+    WARN,
+    ERROR
+}
+
+/**
+ * Log writer function, called by [Logger] to write log messages.
+ */
+export type LoggerWriter = (level: LogLevel, message: string) => void
+
+/**
+ * Provides a thin wrapper around a log class that can be changed to different implementations.
+ */
+export class Logger {
+    private writer: LoggerWriter
+
+    constructor() {
+        this.writer = (level: LogLevel, message: string) => {
+            // eslint-disable-next-line no-console
+            console.log(`[${LogLevel[level]}] ${message}`)
+        }
+    }
+
+    setWriter(writer: LoggerWriter): void {
+        this.writer = writer
+    }
+
+    debug(message: string): void {
+        this.writer(LogLevel.DEBUG, message)
+    }
+
+    cacheDebug(message: string): void {
+        if (state.isCacheDebuggingEnabled()) {
+            this.info(message)
+        } else {
+            this.debug(message)
+        }
+    }
+
+    info(message: string): void {
+        this.writer(LogLevel.INFO, message)
+    }
+
+    notice(message: string): void {
+        this.writer(LogLevel.NOTICE, message)
+    }
+
+    warn(message: string): void {
+        this.writer(LogLevel.WARN, message)
+    }
+}

--- a/sources/src/env/state.ts
+++ b/sources/src/env/state.ts
@@ -83,6 +83,17 @@ export class CIState implements CIStateImplementation {
     }
 
     /**
+     * Checks if the action is being debugged _or_ `GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED` is set in the environment.
+     * @returns True if debugging of the cache is enabled.
+     */
+    isCacheDebuggingEnabled(): boolean {
+        if (this.isDebug()) {
+            return true
+        }
+        return process.env['GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED'] ? true : false
+    }
+
+    /**
      * @inheritdoc
      */
     get(key: string): string {


### PR DESCRIPTION
In order to support more environments, we abstract away `@actions/core`'s logging functionality
behind it's own type. This allows replacement with environment-specific versions.

Note: This PR does not replace all, there is a follow-up to finish replacing. The intention is
to have the new content reviewed vs. the "find and replace" PR following.

Part of gradle/actions#502.